### PR TITLE
Add non-receiver functions

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,20 +4,20 @@ import (
 	"regexp"
 )
 
-type RegexTraPper struct {
+type Regextra struct {
 	*regexp.Regexp
 }
 
 // returns value for given regex captureGroupName (subexpression) if found
 //  - match -> "{matchedValue}", true
 //  - no match -> "", false
-func (rtp RegexTraPper) SubexpValue(target, cgName string) (string, bool) {
-	cgIndex := rtp.SubexpIndex(cgName)
+func (rex Regextra) SubexpValue(target, cgName string) (string, bool) {
+	cgIndex := rex.SubexpIndex(cgName)
 	if cgIndex == -1 {
 		return "", false
 	}
 
-	matches := rtp.FindStringSubmatch(target)
+	matches := rex.FindStringSubmatch(target)
 	if matches == nil {
 		return "", false
 	}
@@ -26,17 +26,17 @@ func (rtp RegexTraPper) SubexpValue(target, cgName string) (string, bool) {
 }
 
 // returns map of all regex captureGroupNames (subexpressions) and their values
-func (rtp RegexTraPper) SubexpMap(target string) map[string]string {
+func (rex Regextra) SubexpMap(target string) map[string]string {
 	cgMap := map[string]string{}
 
-	matches := rtp.FindStringSubmatch(target)
+	matches := rex.FindStringSubmatch(target)
 	if matches == nil {
 		return cgMap
 	}
 
-	for i, name := range rtp.SubexpNames() {
+	for i, name := range rex.SubexpNames() {
 		if i != 0 && name != "" {
-			value, ok := rtp.SubexpValue(target, name)
+			value, ok := rex.SubexpValue(target, name)
 			if ok {
 				cgMap[name] = value
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -16,8 +16,8 @@ func TestRegexTraPper_SubexpValue(t *testing.T) {
 		Regexp *regexp.Regexp
 	}
 	type args struct {
-		target     string
-		subexpName string
+		target string
+		cgName string
 	}
 	tests := []struct {
 		name      string
@@ -32,8 +32,8 @@ func TestRegexTraPper_SubexpValue(t *testing.T) {
 				Regexp: testPattern,
 			},
 			args: args{
-				target:     testTarget,
-				subexpName: "first",
+				target: testTarget,
+				cgName: "first",
 			},
 			want:      "one",
 			wantFound: true,
@@ -44,8 +44,8 @@ func TestRegexTraPper_SubexpValue(t *testing.T) {
 				Regexp: testPattern,
 			},
 			args: args{
-				target:     testTarget,
-				subexpName: "second",
+				target: testTarget,
+				cgName: "second",
 			},
 			want:      "two",
 			wantFound: true,
@@ -56,8 +56,8 @@ func TestRegexTraPper_SubexpValue(t *testing.T) {
 				Regexp: testPattern,
 			},
 			args: args{
-				target:     testTarget,
-				subexpName: "third",
+				target: testTarget,
+				cgName: "third",
 			},
 			want:      "",
 			wantFound: false,
@@ -68,8 +68,8 @@ func TestRegexTraPper_SubexpValue(t *testing.T) {
 				Regexp: regexp.MustCompile(`(?P<price>\$\d+(,\d{3})*(\.\d{1,2})?)`),
 			},
 			args: args{
-				target:     "The price is $1,234.56",
-				subexpName: "price",
+				target: "The price is $1,234.56",
+				cgName: "price",
 			},
 			want:      "$1,234.56",
 			wantFound: true,
@@ -77,10 +77,10 @@ func TestRegexTraPper_SubexpValue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rtp := RegexTraPper{
+			rtp := Regextra{
 				Regexp: tt.fields.Regexp,
 			}
-			got, found := rtp.SubexpValue(tt.args.target, tt.args.subexpName)
+			got, found := rtp.SubexpValue(tt.args.target, tt.args.cgName)
 			if got != tt.want {
 				t.Errorf("RegexTraPper.SubexpValue() got = %v, want %v", got, tt.want)
 			}
@@ -130,10 +130,10 @@ func TestRegexTraPper_SubexpMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rtp := RegexTraPper{
+			rex := Regextra{
 				Regexp: tt.fields.Regexp,
 			}
-			if got := rtp.SubexpMap(tt.args.target); !reflect.DeepEqual(got, tt.want) {
+			if got := rex.SubexpMap(tt.args.target); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("RegexTraPper.SubexpMap() = %v, want %v", got, tt.want)
 			}
 		})

--- a/smoosh.go
+++ b/smoosh.go
@@ -1,0 +1,13 @@
+package regextra
+
+import (
+	"regexp"
+)
+
+func SubexpValue(re *regexp.Regexp, target, cgName string) (string, bool) {
+	return Regextra{re}.SubexpValue(target, cgName)
+}
+
+func SubexpMap(re *regexp.Regexp, target string) map[string]string {
+	return Regextra{re}.SubexpMap(target)
+}

--- a/smoosh_test.go
+++ b/smoosh_test.go
@@ -1,0 +1,112 @@
+package regextra
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+func TestSubexpMap(t *testing.T) {
+	type args struct {
+		re     *regexp.Regexp
+		target string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "found group names with values",
+			args: args{
+				re:     testPattern,
+				target: testTarget,
+			},
+			want: map[string]string{
+				"first":  "one",
+				"second": "two",
+			},
+		},
+		{
+			name: "found none",
+			args: args{
+				re:     testPattern,
+				target: "one two three",
+			},
+			want: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SubexpMap(tt.args.re, tt.args.target); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SubexpMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubexpValue(t *testing.T) {
+	type args struct {
+		re     *regexp.Regexp
+		target string
+		cgName string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      string
+		wantFound bool
+	}{
+		{
+			name: "found one",
+			args: args{
+				re:     testPattern,
+				target: testTarget,
+				cgName: "first",
+			},
+			want:      "one",
+			wantFound: true,
+		},
+		{
+			name: "found two",
+			args: args{
+				re:     testPattern,
+				target: testTarget,
+				cgName: "second",
+			},
+			want:      "two",
+			wantFound: true,
+		},
+		{
+			name: "find none",
+			args: args{
+				re:     testPattern,
+				target: testTarget,
+				cgName: "third",
+			},
+			want:      "",
+			wantFound: false,
+		},
+		{
+			name: "get the price",
+			args: args{
+				re:     regexp.MustCompile(`(?P<price>\$\d+(,\d{3})*(\.\d{1,2})?)`),
+				target: "The price is $1,234.56",
+				cgName: "price",
+			},
+			want:      "$1,234.56",
+			wantFound: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := SubexpValue(tt.args.re, tt.args.target, tt.args.cgName)
+			if got != tt.want {
+				t.Errorf("SubexpValue() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.wantFound {
+				t.Errorf("SubexpValue() got1 = %v, want %v", got1, tt.wantFound)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Details
Provides functions that don't require wrapping of regexp package type. 

In the future, the receiver versions may be made private (and tests for private functions removed), but depends on DX.