### PR TITLE
Release v0.2.1: Add AllNamedGroups function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2025-10-04
+
+### Added
+- `AllNamedGroups` function to extract all values for each named capture group as `map[string][]string`
+- Handles patterns with duplicate group names, collecting all matches for each group name
+- Comprehensive test coverage for `AllNamedGroups` including duplicate group name scenarios
+- Example test for `AllNamedGroups` for pkg.go.dev documentation
+
 ## [0.2.0] - 2025-10-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ func main() {
         fmt.Println("Name:", name) // Output: Name: Alice
     }
     
-    // Get all named groups from first match as a map
+    // Get all named groups as a map. If a group matches multiple times, the last match value will be returned
     groups := regextra.NamedGroups(re, "Alice 30")
     fmt.Println(groups) // Output: map[age:30 name:Alice]
     
@@ -62,7 +62,7 @@ price, ok := regextra.FindNamed(re, "Total: $19.99", "price")
 
 ### `NamedGroups(re *regexp.Regexp, target string) map[string]string`
 
-Extract all named capture groups from the first match as a map.
+Extract all named capture groups as a map. If a group name appears multiple times, only the last match is returned.
 
 Returns an empty map if no match is found.
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,14 @@ func main() {
         fmt.Println("Name:", name) // Output: Name: Alice
     }
     
-    // Get all named groups as a map
+    // Get all named groups from first match as a map
     groups := regextra.NamedGroups(re, "Alice 30")
     fmt.Println(groups) // Output: map[age:30 name:Alice]
+    
+    // Get all values for duplicate group names
+    re2 := regexp.MustCompile(`(?P<word>\w+) (?P<word>\w+)`)
+    allGroups := regextra.AllNamedGroups(re2, "hello world")
+    fmt.Println(allGroups) // Output: map[word:[hello world]]
 }
 ```
 
@@ -57,7 +62,7 @@ price, ok := regextra.FindNamed(re, "Total: $19.99", "price")
 
 ### `NamedGroups(re *regexp.Regexp, target string) map[string]string`
 
-Extract all named capture groups as a map.
+Extract all named capture groups from the first match as a map.
 
 Returns an empty map if no match is found.
 
@@ -65,6 +70,18 @@ Returns an empty map if no match is found.
 re := regexp.MustCompile(`(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})`)
 groups := regextra.NamedGroups(re, "Date: 2025-10-04")
 // groups = map[string]string{"year": "2025", "month": "10", "day": "04"}
+```
+
+### `AllNamedGroups(re *regexp.Regexp, target string) map[string][]string`
+
+Extract all values for each named capture group, handling duplicate group names within a single match.
+
+Returns an empty map if no match is found.
+
+```go
+re := regexp.MustCompile(`(?P<word>\w+) (?P<word>\w+) (?P<word>\w+)`)
+allGroups := regextra.AllNamedGroups(re, "one two three")
+// allGroups = map[string][]string{"word": []string{"one", "two", "three"}}
 ```
 
 ## Why regextra?

--- a/main.go
+++ b/main.go
@@ -64,3 +64,29 @@ func NamedGroups(re *regexp.Regexp, target string) map[string]string {
 
 	return result
 }
+
+// AllNamedGroups returns a map where each key is a named capture group and the value
+// is a slice of all matches for that group. This handles patterns where the same
+// group name appears multiple times.
+//
+// Example:
+//
+//	re := regexp.MustCompile(`(?P<word>\w+) (?P<word>\w+)`)
+//	allGroups := regextra.AllNamedGroups(re, "hello world")
+//	// allGroups = map[string][]string{"word": []string{"hello", "world"}}
+func AllNamedGroups(re *regexp.Regexp, target string) map[string][]string {
+	result := make(map[string][]string)
+
+	matches := re.FindStringSubmatch(target)
+	if matches == nil {
+		return result
+	}
+
+	for i, name := range re.SubexpNames() {
+		if i != 0 && name != "" {
+			result[name] = append(result[name], matches[i])
+		}
+	}
+
+	return result
+}

--- a/main_test.go
+++ b/main_test.go
@@ -130,3 +130,78 @@ func ExampleNamedGroups() {
 	}
 	// Output: year=2025 month=10 day=04
 }
+
+func TestAllNamedGroups(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		target  string
+		want    map[string][]string
+	}{
+		{
+			name:    "duplicate group names in same match",
+			pattern: `(?P<word>\w+) (?P<word>\w+)`,
+			target:  "hello world",
+			want: map[string][]string{
+				"word": {"hello", "world"},
+			},
+		},
+		{
+			name:    "multiple different groups",
+			pattern: `(?P<name>\w+) (?P<age>\d+)`,
+			target:  "Alice 30",
+			want: map[string][]string{
+				"name": {"Alice"},
+				"age":  {"30"},
+			},
+		},
+		{
+			name:    "three duplicate group names",
+			pattern: `(?P<item>\w+) (?P<item>\w+) (?P<item>\w+)`,
+			target:  "one two three",
+			want: map[string][]string{
+				"item": {"one", "two", "three"},
+			},
+		},
+		{
+			name:    "mixed duplicate and unique groups",
+			pattern: `(?P<word>\w+) (?P<num>\d+) (?P<word>\w+)`,
+			target:  "hello 123 world",
+			want: map[string][]string{
+				"word": {"hello", "world"},
+				"num":  {"123"},
+			},
+		},
+		{
+			name:    "no match returns empty map",
+			pattern: `(?P<digit>\d+)`,
+			target:  "abc",
+			want:    map[string][]string{},
+		},
+		{
+			name:    "single group single match",
+			pattern: `(?P<price>\$\d+\.\d{2})`,
+			target:  "Total: $19.99",
+			want: map[string][]string{
+				"price": {"$19.99"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			re := regexp.MustCompile(tt.pattern)
+			got := AllNamedGroups(re, tt.target)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AllNamedGroups() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func ExampleAllNamedGroups() {
+	re := regexp.MustCompile(`(?P<word>\w+) (?P<word>\w+) (?P<word>\w+)`)
+	allGroups := AllNamedGroups(re, "one two three")
+
+	fmt.Printf("word: %v\n", allGroups["word"])
+	// Output: word: [one two three]
+}


### PR DESCRIPTION
## Changes

### Added
- `AllNamedGroups` function returning `map[string][]string`
- Handles duplicate group names by collecting all values per group name
- Comprehensive test coverage with 100% coverage maintained

### Documentation
- Updated README with AllNamedGroups examples
- Clarified NamedGroups behavior with duplicate group names
- Added Example tests for pkg.go.dev

## Testing
All tests pass with 100% coverage:
```
PASS
coverage: 100.0% of statements
```

This is a minor release adding new functionality without breaking existing API.