### PR TITLE
chore: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report incorrect behavior in regextra
+title: ''
+labels: kind:bug
+assignees: ''
+---
+
+## Summary
+<!-- One-sentence description of what's wrong. -->
+
+## Reproduction
+
+```go
+re := regexp.MustCompile(`...`)
+// minimal code that triggers the bug
+```
+
+**Input string:** ``...``
+**Expected:** <!-- what you expected to happen -->
+**Actual:** <!-- what actually happened, including any error -->
+
+## Environment
+
+- regextra version: <!-- output of `go list -m github.com/jecoms/regextra` -->
+- Go version: <!-- output of `go version` -->
+- OS / arch: <!-- e.g. macOS 14.5 / arm64 -->
+
+## Additional context
+<!-- Any other relevant detail: surrounding pattern, related stdlib regexp behavior, etc. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/Jecoms/regextra/discussions
+    about: Open-ended questions and design discussions go in Discussions, not Issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Propose an API addition or enhancement
+title: ''
+labels: kind:feature
+assignees: ''
+---
+
+## Use case
+<!-- The real-world problem you're trying to solve. What pattern do you have to write today? -->
+
+## Proposed API
+
+```go
+// signature(s) you'd like to see
+```
+
+```go
+// example call site
+```
+
+## Alternatives considered
+<!-- Workarounds with the current API, or shapes you rejected and why. -->
+
+## Compatibility
+<!-- Is this additive, or does it change/replace existing behavior? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--
+Use a Conventional Commits subject for the PR title (e.g. `feat: …`, `fix: …`,
+`chore: …`, `ci: …`, `docs: …`, `refactor: …`, `test: …`, `perf: …`). Squash-merge
+turns the PR title into the commit subject — keep it short and accurate.
+-->
+
+## Summary
+<!-- What changed and why. One short paragraph or 2–3 bullets. -->
+
+## Type of change
+- [ ] Feature (new public API or behavior)
+- [ ] Fix (bug correction, no API change)
+- [ ] Chore / CI / docs / refactor (no behavior change)
+- [ ] Breaking change (semver minor pre-1.0, major post-1.0)
+
+## CHANGELOG
+<!-- For features and fixes, paste the entry you added under `## [Unreleased]`. -->
+
+## Test plan
+- [ ] `go test ./...` passes locally
+- [ ] `go test -race ./...` passes if touching shared state
+- [ ] `golangci-lint run` is clean
+- [ ] New behavior covered by tests / examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `.github/ISSUE_TEMPLATE/{bug_report,feature_request}.md` and `.github/PULL_REQUEST_TEMPLATE.md` so contributors and AI agents land on prompts that ask for the information maintainers need (Go version, regex pattern, expected vs actual; use case + proposed API; CHANGELOG + test plan).
+- `.github/ISSUE_TEMPLATE/config.yml` routes open-ended questions to GitHub Discussions and disables blank issues.
+
 ## [0.3.0] - 2025-10-06
 
 ### Added


### PR DESCRIPTION
## Summary

- `.github/ISSUE_TEMPLATE/bug_report.md` — asks for regex pattern, input string, expected vs actual, and Go / regextra / OS versions.
- `.github/ISSUE_TEMPLATE/feature_request.md` — prompts for use case, proposed API signature, alternatives, compatibility surface.
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues and routes questions to Discussions.
- `.github/PULL_REQUEST_TEMPLATE.md` — type-of-change checklist, CHANGELOG entry pointer, test plan.

Also adds the `## [Unreleased]` section to `CHANGELOG.md` so subsequent PRs have a target.

## Type of change
- [x] Chore / docs (no behavior change)

## Test plan
- [x] `go test ./...` — unaffected (no Go files changed)
- [x] `golangci-lint run` — unaffected
- [ ] After merge: open a fresh issue/PR via the GitHub UI and confirm the templates render

Closes #43 (bead re-5ps).