### PR TITLE
ci: add CodeQL static analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly Monday 09:00 UTC
+    - cron: '0 9 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (Go)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5
+        with:
+          go-version: '1.24'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a
+        with:
+          languages: go
+
+      - name: Build
+        run: go build ./...
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a
+        with:
+          category: '/language:go'


### PR DESCRIPTION
## Summary

Adds `.github/workflows/codeql.yml` running GitHub's CodeQL on Go code.

- Triggers: PR + push to main + weekly Monday 09:00 UTC schedule.
- SHA-pinned actions matching the project's hardening posture.
- Concurrency-cancels superseded runs per ref.

CodeQL is free for public repos and surfaces injection / unsafe-pointer / nil-deref issues out of the box. Findings show in the Security tab.

## Type of change
- [x] Chore / ci (no behavior change)

## Test plan
- [ ] First run on this PR completes successfully
- [ ] Security tab populates with the analysis run

Closes #41 (bead re-u17).