### PR TITLE
ci: auto-merge Dependabot PRs for action / dev-dep bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,39 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge for action / dev-dependency bumps
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for github-actions and dev gomod bumps
+        # Only auto-merge:
+        #  - github-actions ecosystem (any update type)
+        #  - gomod ecosystem ONLY for direct:development dependencies AND patch/minor updates
+        # Production direct deps and major bumps still require human review.
+        if: |
+          steps.metadata.outputs.package-ecosystem == 'github-actions' ||
+          (steps.metadata.outputs.package-ecosystem == 'gomod' &&
+           steps.metadata.outputs.dependency-type == 'direct:development' &&
+           (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+            steps.metadata.outputs.update-type == 'version-update:semver-minor'))
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dependabot-auto-merge.yml` enabling GitHub auto-merge on Dependabot PRs once required checks pass — but only for the safe class:

- All `github-actions` ecosystem bumps (any update type).
- `gomod` ecosystem **only** for `direct:development` deps **and** `semver-patch` / `semver-minor` updates.

Production direct deps and major bumps still require human review.

Uses `dependabot/fetch-metadata@v2` (SHA-pinned) to read PR metadata. `gh pr merge --auto --squash` queues the merge once the configured required-status-checks all turn green; until then it just sits.

## Type of change
- [x] Chore / ci (no behavior change)

## Test plan
- [ ] First Dependabot PR after merge gets auto-merge enabled and lands without manual click once tests pass
- [ ] Major bumps and production direct-dep bumps stay open (no auto-merge)

## Notes

- Required-checks gate must be configured on `main` branch protection for auto-merge to actually wait for tests; otherwise `--auto` merges immediately.

Closes #33 (bead re-d2y).