### PR TITLE
ci: enforce 85% coverage floor on the test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,23 @@ jobs:
     - name: Run tests
       run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
+    - name: Enforce coverage threshold
+      env:
+        # Floor below which the build fails. Current baseline is ~87.6%; this
+        # leaves ~3 points of slack to absorb small refactors without forcing
+        # tests on every micro-PR.
+        MIN_COVERAGE: '85.0'
+      run: |
+        set -euo pipefail
+        total=$(go tool cover -func=coverage.txt | awk '/^total:/ {print $3}' | tr -d '%')
+        echo "Total coverage: ${total}%"
+        echo "Minimum:        ${MIN_COVERAGE}%"
+        awk -v t="$total" -v m="$MIN_COVERAGE" 'BEGIN { exit (t+0 < m+0) ? 1 : 0 }' || {
+          echo "::error::Coverage ${total}% is below the required minimum ${MIN_COVERAGE}%."
+          exit 1
+        }
+        echo "✓ Coverage meets the threshold."
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
       with:


### PR DESCRIPTION
## Summary

Adds a "Enforce coverage threshold" step to the existing `test` job that parses the `total:` line from `go tool cover -func=coverage.txt` and fails the build when overall coverage drops below 85%.

Codecov upload still runs unchanged. The new gate is what actually fails the workflow.

## Type of change
- [x] Chore / ci (no behavior change)

## Test plan
- [x] Locally: `go tool cover -func=coverage.txt | awk '/^total:/ {print $3}'` reports 87.6% — passes the 85% floor.
- [ ] First CI run on this PR: gate passes.
- [ ] Future PR that intentionally drops coverage below 85%: gate fails.

## Notes

- Threshold is `MIN_COVERAGE: '85.0'` env on the step. Bump over time as coverage grows.
- Floor is intentionally a few points below the current baseline (~87.6%) so micro-refactors don't get blocked. Trade-off: a sustained 2-point drop won't fail until it reaches the floor.

Closes #38 (bead re-oq6).