### PR TITLE
ci: expand test matrix to Go 1.24, 1.25, 1.26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,15 @@ permissions:
 
 jobs:
   test:
-    name: Test
+    name: Test (Go ${{ matrix.go-version }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        go-version: ['1.24']
+        # go.mod stays at 1.24 (the floor for consumers). Matrix tests against
+        # the floor + the two newest toolchains so we catch regressions on new
+        # Go without raising the consumer floor.
+        go-version: ['1.24', '1.25', '1.26']
     
     steps:
     - name: Check out code


### PR DESCRIPTION
## Summary

Test matrix expands from `['1.24']` to `['1.24', '1.25', '1.26']` in `test.yml`. `go.mod` stays at 1.24 (the consumer floor) — only the test matrix is broader, so regressions on newer toolchains surface in CI without forcing consumers to upgrade.

`fail-fast: false` lets all three legs finish so triage shows which version broke first.

## Type of change
- [x] Chore / ci (no behavior change)

## Test plan
- [x] Locally: `go version` (1.24.0) — tests pass
- [ ] First CI run: all three matrix legs pass (1.24, 1.25, 1.26)
- [ ] If a future PR breaks 1.26 only, CI surfaces it on that leg specifically

## Notes

- `lint` and `vet` jobs stay on 1.24 (single version) — those are stylistic gates, not language-feature gates. No need to multiply them.
- Codecov upload now runs three times per workflow (one per matrix leg). Codecov merges by flag (`unittests`); the existing `fail_ci_if_error: false` keeps double-upload warnings non-fatal.

Closes re-6mj.