### PR TITLE
feat: add FindAllNamed for one group across all matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ price, ok := regextra.FindNamed(re, "Total: $19.99", "price")
 // price = "$19.99", ok = true
 ```
 
+### `FindAllNamed(re *regexp.Regexp, target, groupName string) []string`
+
+Extract every value of a single named capture group across all matches.
+
+Returns `nil` if the group name is not declared on the regex; an empty slice if the group is declared but the regex has no matches.
+
+```go
+re := regexp.MustCompile(`(?P<word>\S+)`)
+words := regextra.FindAllNamed(re, "alpha beta gamma", "word")
+// words = []string{"alpha", "beta", "gamma"}
+```
+
+For a single match, prefer `FindNamed`. To collect every named group's values across all matches, use `AllNamedGroups`.
+
 ### `NamedGroups(re *regexp.Regexp, target string) map[string]string`
 
 Extract all named capture groups as a map. If a group name appears multiple times, only the last match is returned.

--- a/main.go
+++ b/main.go
@@ -44,6 +44,36 @@ func FindNamed(re *regexp.Regexp, target, groupName string) (string, bool) {
 	return matches[index], true
 }
 
+// FindAllNamed returns every value of the named capture group across all
+// matches of re in target. Returns nil if the group name is not declared on
+// the regex; an empty slice if the group is declared but the regex has no
+// matches.
+//
+// Example:
+//
+//	re := regexp.MustCompile(`(?P<word>\S+)`)
+//	words := regextra.FindAllNamed(re, "alpha beta gamma", "word")
+//	// words = []string{"alpha", "beta", "gamma"}
+//
+// For a single match, prefer [FindNamed] which returns (value, ok).
+// To collect every named group's values across all matches, use
+// [AllNamedGroups].
+func FindAllNamed(re *regexp.Regexp, target, groupName string) []string {
+	index := re.SubexpIndex(groupName)
+	if index == -1 {
+		return nil
+	}
+	matches := re.FindAllStringSubmatch(target, -1)
+	if len(matches) == 0 {
+		return []string{}
+	}
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, m[index])
+	}
+	return out
+}
+
 // NamedGroups returns a map of all named capture groups and their matched values
 // from the target string. If no match is found, it returns an empty map.
 //

--- a/main_test.go
+++ b/main_test.go
@@ -119,6 +119,74 @@ func ExampleFindNamed() {
 	// Output: Alice: true
 }
 
+func TestFindAllNamed(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		target  string
+		group   string
+		want    []string
+	}{
+		{
+			name:    "multiple matches collects all values",
+			pattern: `(?P<word>\S+)`,
+			target:  "alpha beta gamma",
+			group:   "word",
+			want:    []string{"alpha", "beta", "gamma"},
+		},
+		{
+			name:    "two-group pattern, picks the requested group",
+			pattern: `(?P<key>\w+)=(?P<val>\d+)`,
+			target:  "a=1 b=2 c=3",
+			group:   "val",
+			want:    []string{"1", "2", "3"},
+		},
+		{
+			name:    "no matches returns empty slice (not nil)",
+			pattern: `(?P<word>[A-Z]+)`,
+			target:  "all lowercase",
+			group:   "word",
+			want:    []string{},
+		},
+		{
+			name:    "undeclared group returns nil",
+			pattern: `(?P<word>\S+)`,
+			target:  "anything",
+			group:   "missing",
+			want:    nil,
+		},
+		{
+			name:    "empty target returns empty slice when group declared",
+			pattern: `(?P<word>\S+)`,
+			target:  "",
+			group:   "word",
+			want:    []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			re := regexp.MustCompile(tt.pattern)
+			got := FindAllNamed(re, tt.target, tt.group)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("FindAllNamed = %v, want nil", got)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FindAllNamed = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func ExampleFindAllNamed() {
+	re := regexp.MustCompile(`(?P<word>\S+)`)
+	words := FindAllNamed(re, "alpha beta gamma", "word")
+	fmt.Println(words)
+	// Output: [alpha beta gamma]
+}
+
 func ExampleNamedGroups() {
 	re := regexp.MustCompile(`(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})`)
 	groups := NamedGroups(re, "Date: 2025-10-04")


### PR DESCRIPTION
## Summary

Adds `FindAllNamed(re *regexp.Regexp, target, groupName string) []string` — extracts every value of a single named capture group across all matches of `re` in `target`.

```go
re := regexp.MustCompile(`(?P<word>\S+)`)
words := regextra.FindAllNamed(re, "alpha beta gamma", "word")
// words = []string{"alpha", "beta", "gamma"}
```

`AllNamedGroups` already returns every group's values across all matches as a `map[string][]string` — the common case is just wanting one group's values, and writing the projection out of `AllNamedGroups` or out of `re.FindAllStringSubmatch` + `re.SubexpIndex` is exactly the boilerplate this package exists to remove.

## Contract

| Input | Returned |
|---|---|
| Group name not declared on regex | `nil` |
| Declared, no matches | `[]string{}` (non-nil) |
| Declared, N matches | `[]string` of length N, match-order |

## Type of change
- [x] Feature (new public API; additive — no behavior change to existing functions)

## CHANGELOG

Will land under `### Added` in `release/v0.4.0`.

## Test plan
- [x] `TestFindAllNamed` covers the four contract cases (multiple matches, two-group pattern, no-match returns empty slice, undeclared group returns nil, empty target)
- [x] `ExampleFindAllNamed` renders on pkg.go.dev
- [x] `go test ./...` — passes
- [x] `go vet ./...` — clean

Closes #30 (bead re-1qu).