### PR TITLE
feat: add Replace for substituting named groups via a map

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ allGroups := regextra.AllNamedGroups(re, "one two three")
 // allGroups = map[string][]string{"word": []string{"one", "two", "three"}}
 ```
 
+### `Replace(re *regexp.Regexp, target string, replacements map[string]string) string`
+
+Substitute the matched span of each named capture group with the value from `replacements`, leaving non-matching text and any groups absent from the map unchanged. `Replace` operates on every match of `re`, in order.
+
+```go
+re := regexp.MustCompile(`(?P<user>\w+)@(?P<domain>[\w.]+)`)
+out := regextra.Replace(re, "alice@example.com bob@other.org", map[string]string{
+    "domain": "redacted",
+})
+// out = "alice@redacted bob@redacted"
+```
+
 ### `Unmarshal(re *regexp.Regexp, target string, v any) error`
 
 Unmarshal regex matches into a struct with automatic type conversion. Similar to `json.Unmarshal`, but for regex patterns.

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -93,6 +94,74 @@ func AllNamedGroups(re *regexp.Regexp, target string) map[string][]string {
 	}
 
 	return result
+}
+
+// Replace substitutes the matched span of each named capture group in
+// target with the value from replacements, leaving non-matching text and
+// any groups absent from the map unchanged. Replace operates on every
+// match of re, in order.
+//
+// If a regex declares a named group but replacements has no entry for it,
+// the original matched text passes through. Groups that don't participate
+// in a match (optional groups returning index -1) are skipped.
+//
+// When named groups overlap (nesting), the outermost-named group whose
+// span is encountered first wins; inner groups inside an already-replaced
+// span are not substituted.
+//
+// Example:
+//
+//	re := regexp.MustCompile(`(?P<user>\w+)@(?P<domain>[\w.]+)`)
+//	out := regextra.Replace(re, "alice@example.com", map[string]string{
+//	    "domain": "redacted",
+//	})
+//	// out = "alice@redacted"
+func Replace(re *regexp.Regexp, target string, replacements map[string]string) string {
+	if len(replacements) == 0 {
+		return target
+	}
+	matches := re.FindAllStringSubmatchIndex(target, -1)
+	if len(matches) == 0 {
+		return target
+	}
+	names := re.SubexpNames()
+
+	type span struct {
+		start, end int
+		repl       string
+	}
+
+	var b strings.Builder
+	cursor := 0
+	for _, m := range matches {
+		spans := make([]span, 0, len(names))
+		for i := 1; i < len(names); i++ {
+			name := names[i]
+			if name == "" {
+				continue
+			}
+			repl, ok := replacements[name]
+			if !ok {
+				continue
+			}
+			s, e := m[2*i], m[2*i+1]
+			if s < 0 || e < 0 {
+				continue
+			}
+			spans = append(spans, span{start: s, end: e, repl: repl})
+		}
+		sort.Slice(spans, func(i, j int) bool { return spans[i].start < spans[j].start })
+		for _, sp := range spans {
+			if sp.start < cursor {
+				continue // already covered (overlap with an earlier substitution)
+			}
+			b.WriteString(target[cursor:sp.start])
+			b.WriteString(sp.repl)
+			cursor = sp.end
+		}
+	}
+	b.WriteString(target[cursor:])
+	return b.String()
 }
 
 // Unmarshal extracts named capture groups from the target string and assigns them

--- a/main_test.go
+++ b/main_test.go
@@ -206,6 +206,91 @@ func ExampleAllNamedGroups() {
 	// Output: word: [one two three]
 }
 
+func TestReplace(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		target  string
+		repl    map[string]string
+		want    string
+	}{
+		{
+			name:    "single match, single substitution",
+			pattern: `(?P<user>\w+)@(?P<domain>[\w.]+)`,
+			target:  "alice@example.com",
+			repl:    map[string]string{"domain": "redacted"},
+			want:    "alice@redacted",
+		},
+		{
+			name:    "single match, all groups substituted",
+			pattern: `(?P<user>\w+)@(?P<domain>[\w.]+)`,
+			target:  "alice@example.com",
+			repl:    map[string]string{"user": "bob", "domain": "redacted"},
+			want:    "bob@redacted",
+		},
+		{
+			name:    "multiple matches, every match substituted",
+			pattern: `(?P<word>\w+)`,
+			target:  "alpha beta gamma",
+			repl:    map[string]string{"word": "X"},
+			want:    "X X X",
+		},
+		{
+			name:    "multiple matches, key not in map passes through",
+			pattern: `(?P<key>\w+)=(?P<val>\d+)`,
+			target:  "a=1 b=2",
+			repl:    map[string]string{"val": "?"},
+			want:    "a=? b=?",
+		},
+		{
+			name:    "no match returns target unchanged",
+			pattern: `(?P<word>[A-Z]+)`,
+			target:  "no matches here",
+			repl:    map[string]string{"word": "X"},
+			want:    "no matches here",
+		},
+		{
+			name:    "empty replacements returns target unchanged",
+			pattern: `(?P<word>\w+)`,
+			target:  "alpha beta",
+			repl:    map[string]string{},
+			want:    "alpha beta",
+		},
+		{
+			name:    "unknown group name in map is ignored",
+			pattern: `(?P<word>\w+)`,
+			target:  "hello",
+			repl:    map[string]string{"missing": "X"},
+			want:    "hello",
+		},
+		{
+			name:    "preserves non-matching text between matches",
+			pattern: `(?P<num>\d+)`,
+			target:  "a 1 b 2 c 3 d",
+			repl:    map[string]string{"num": "*"},
+			want:    "a * b * c * d",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			re := regexp.MustCompile(tt.pattern)
+			got := Replace(re, tt.target, tt.repl)
+			if got != tt.want {
+				t.Errorf("Replace = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func ExampleReplace() {
+	re := regexp.MustCompile(`(?P<user>\w+)@(?P<domain>[\w.]+)`)
+	out := Replace(re, "alice@example.com bob@other.org", map[string]string{
+		"domain": "redacted",
+	})
+	fmt.Println(out)
+	// Output: alice@redacted bob@redacted
+}
+
 func TestUnmarshal(t *testing.T) {
 	t.Run("basic string fields", func(t *testing.T) {
 		type Person struct {


### PR DESCRIPTION
## Summary

Adds `Replace(re *regexp.Regexp, target string, replacements map[string]string) string`. Substitutes the matched span of each named capture group with the value from `replacements`, leaving everything else (non-matching text and absent groups) unchanged. Operates on every match of `re`, in order.

```go
re := regexp.MustCompile(`(?P<user>\w+)@(?P<domain>[\w.]+)`)
out := regextra.Replace(re, "alice@example.com bob@other.org", map[string]string{
    "domain": "redacted",
})
// out = "alice@redacted bob@redacted"
```

The current alternative is `re.ReplaceAllStringFunc` with manual `SubexpNames` indexing — exactly the boilerplate this package exists to remove.

## Contract

| Case | Behavior |
|---|---|
| Group declared on regex, key in map | Substitute |
| Group declared on regex, key NOT in map | Pass through (preserve original) |
| Key in map, NOT declared on regex | Silently ignored |
| Group did not participate in match (optional, idx -1) | Skip |
| Overlapping nested groups | Outer (encountered first by start position) wins |
| No matches at all | Return `target` unchanged |
| Empty `replacements` | Return `target` unchanged (fast path) |

## Type of change
- [x] Feature (new public API; additive)

## Test plan
- [x] `TestReplace` covers eight cases: single match, all-groups, multi-match, partial map, no-match, empty replacements, unknown key, non-matching text preservation
- [x] `ExampleReplace` renders on pkg.go.dev
- [x] `go test ./...` — passes
- [x] `go vet ./...` — clean

Closes #37 (bead re-kkn).