### PR TITLE
feat: add Validate for init-time assertion of required named groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ out := regextra.Replace(re, "alice@example.com bob@other.org", map[string]string
 // out = "alice@redacted bob@redacted"
 ```
 
+### `Validate(re *regexp.Regexp, required ...string) error`
+
+Returns an error listing every required group name that is not declared on `re`. Use it for init-time assertions in services that compile patterns once: catch typos at startup rather than at the first (mis-)matched request.
+
+```go
+re := regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
+
+if err := regextra.Validate(re, "name", "age", "ssn"); err != nil {
+    // err: regextra.Validate: missing named groups: ssn
+}
+```
+
 ### `Unmarshal(re *regexp.Regexp, target string, v any) error`
 
 Unmarshal regex matches into a struct with automatic type conversion. Similar to `json.Unmarshal`, but for regex patterns.

--- a/main.go
+++ b/main.go
@@ -194,6 +194,39 @@ func Replace(re *regexp.Regexp, target string, replacements map[string]string) s
 	return b.String()
 }
 
+// Validate returns an error listing every required group name that is not
+// declared on re. Useful for init-time assertions in services that compile
+// patterns once: catch typos at startup rather than at the first
+// (mis-)matched request.
+//
+// Returns nil when every required name is declared. The error message lists
+// the missing names in the order they were passed.
+//
+// Example:
+//
+//	re := regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
+//	if err := regextra.Validate(re, "name", "age", "missing"); err != nil {
+//	    // err: regextra.Validate: missing named groups: missing
+//	}
+func Validate(re *regexp.Regexp, required ...string) error {
+	declared := make(map[string]struct{}, len(re.SubexpNames()))
+	for _, n := range re.SubexpNames() {
+		if n != "" {
+			declared[n] = struct{}{}
+		}
+	}
+	var missing []string
+	for _, name := range required {
+		if _, ok := declared[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf("regextra.Validate: missing named groups: %s", strings.Join(missing, ", "))
+}
+
 // Unmarshal extracts named capture groups from the target string and assigns them
 // to the corresponding fields in the provided struct pointer.
 //

--- a/main_test.go
+++ b/main_test.go
@@ -359,6 +359,66 @@ func ExampleReplace() {
 	// Output: alice@redacted bob@redacted
 }
 
+func TestValidate(t *testing.T) {
+	re := regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
+
+	t.Run("all declared returns nil", func(t *testing.T) {
+		if err := Validate(re, "name", "age"); err != nil {
+			t.Errorf("Validate returned %v, want nil", err)
+		}
+	})
+
+	t.Run("subset of declared returns nil", func(t *testing.T) {
+		if err := Validate(re, "name"); err != nil {
+			t.Errorf("Validate returned %v, want nil", err)
+		}
+	})
+
+	t.Run("empty required returns nil", func(t *testing.T) {
+		if err := Validate(re); err != nil {
+			t.Errorf("Validate returned %v, want nil", err)
+		}
+	})
+
+	t.Run("single missing reports it", func(t *testing.T) {
+		err := Validate(re, "name", "ssn")
+		if err == nil {
+			t.Fatal("Validate returned nil, want error")
+		}
+		want := "regextra.Validate: missing named groups: ssn"
+		if err.Error() != want {
+			t.Errorf("Validate error = %q, want %q", err.Error(), want)
+		}
+	})
+
+	t.Run("multiple missing preserves request order", func(t *testing.T) {
+		err := Validate(re, "ssn", "age", "email", "name", "phone")
+		if err == nil {
+			t.Fatal("Validate returned nil, want error")
+		}
+		want := "regextra.Validate: missing named groups: ssn, email, phone"
+		if err.Error() != want {
+			t.Errorf("Validate error = %q, want %q", err.Error(), want)
+		}
+	})
+
+	t.Run("regex with no named groups, all required missing", func(t *testing.T) {
+		bare := regexp.MustCompile(`\w+`)
+		err := Validate(bare, "name")
+		if err == nil {
+			t.Fatal("Validate returned nil, want error")
+		}
+	})
+}
+
+func ExampleValidate() {
+	re := regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
+	if err := Validate(re, "name", "age", "ssn"); err != nil {
+		fmt.Println(err)
+	}
+	// Output: regextra.Validate: missing named groups: ssn
+}
+
 func TestUnmarshal(t *testing.T) {
 	t.Run("basic string fields", func(t *testing.T) {
 		type Person struct {


### PR DESCRIPTION
## Summary

Adds `Validate(re *regexp.Regexp, required ...string) error` — returns an error listing every required group name that is not declared on `re`.

```go
re := regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)

if err := regextra.Validate(re, "name", "age", "ssn"); err != nil {
    // err: regextra.Validate: missing named groups: ssn
}
```

## Why this matters — the failure mode `Validate` exists to prevent

Every other function in regextra (`FindNamed`, `NamedGroups`, `Unmarshal`, …) takes a *group name string*. If you typo that string, or if someone changes the regex without changing the call sites, the package returns a benign empty value and your code silently misbehaves. The pattern is correct. The call sites are correct. The connection between them is wrong, and nothing fails loudly.

This bites hardest in three real shapes:

### 1. Package-level `var = regexp.MustCompile(...)` services

The dominant Go idiom is to compile patterns once at process startup:

```go
var logRE = regexp.MustCompile(
    `(?P<ts>\S+) (?P<level>\w+) (?P<msg>.*)`,
)

func parseLine(s string) (LogEntry, bool) {
    return regextra.Unmarshal(logRE, s, &entry), ...
}
```

Today: a typo (`level` → `lvl` in the regex, or `Level` field tagged `regex:"lvl"` in the struct) costs you exactly nothing at startup. The first request hits prod, the field stays at its zero value, and the bug surfaces 6 hours later in a log volume nobody opens.

With `Validate`, you assert the contract once at boot:

```go
func init() {
    if err := regextra.Validate(logRE, "ts", "level", "msg"); err != nil {
        log.Fatal(err)
    }
}
```

The deploy fails before traffic lands.

### 2. User-supplied / config-driven patterns

Tools that accept regex from config (log shippers, ETL transforms, alerting rules, scrapers) store the pattern and *trust* it carries the groups the rest of the system expects:

```go
re, err := regexp.Compile(rule.Pattern)        // user wrote this
if err != nil { return err }                    // syntax — already gated
if err := regextra.Validate(re, "host", "metric", "value"); err != nil {
    return fmt.Errorf("rule %s: %w", rule.ID, err)   // semantics — now also gated
}
```

`regexp.Compile` only catches syntactic errors. `Validate` is the missing semantic gate.

### 3. Refactors and migrations

Renaming `(?P<user>...)` to `(?P<username>...)` in a 200-line regex is exactly the kind of edit that compiles cleanly and breaks every consumer silently. A `Validate` call (or six) sitting in init/test code turns a hidden runtime bug into an immediate compile-or-test-time failure during the migration.

## Why this is a separate function and not just merged into the others

`Unmarshal` could (in theory) error when a struct field's `regex:"foo"` tag points at an undeclared group. That would be a per-call check tied to one specific use case. `Validate`:

- has zero allocation when the pattern is correct,
- runs once at startup, not on every request,
- works with `FindNamed` / `NamedGroups` / hand-rolled consumers that don't go through `Unmarshal`,
- doesn't change the signature of any existing function (no breaking change to error paths).

It's the cheap, opt-in version of the assertion you'd otherwise have to copy-paste at every call site.

## Contract

| Case | Behavior |
|---|---|
| All required declared on `re` | `nil` |
| Empty required list | `nil` (vacuous truth — every required is satisfied) |
| One required name missing | Error: `regextra.Validate: missing named groups: <name>` |
| Multiple missing | Comma-joined list, **preserving request order** (not regex declaration order) so the error matches the caller's mental list |
| Regex declares zero named groups | Every required is missing |

## Type of change
- [x] Feature (new public API; additive)

## Test plan
- [x] `TestValidate` covers the six cases including order preservation and the no-named-groups regex case
- [x] `ExampleValidate` renders on pkg.go.dev
- [x] `go test ./...` — passes
- [x] `go vet ./...` — clean
- [x] Rebased onto `main` after `feat/find-all-named` and `feat/replace` landed; conflicts in `main.go` / `main_test.go` / `README.md` were insertion-order overlaps only, both functions kept

Closes #35 (bead re-f0m).