### PR TITLE
feat: add RegexUnmarshaler interface for caller-defined type conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,47 @@ err := regextra.Unmarshal(re, "alice@example.com", &email)
 // email.Username = "alice", email.Domain = "example.com"
 ```
 
+### `RegexUnmarshaler` interface
+
+Mirror of `encoding.TextUnmarshaler` for regextra's unmarshal path. When a destination field's pointer type satisfies this interface, `Unmarshal` (and `UnmarshalAll`) call `UnmarshalRegex` with the matched group value instead of running the built-in string/int/uint/float/bool conversion.
+
+```go
+type RegexUnmarshaler interface {
+    UnmarshalRegex(value string) error
+}
+```
+
+The extension point for caller-defined types the built-in type switch can't handle (URLs, enums, big numbers, IP addresses, etc.).
+
+```go
+type Status int
+
+const (
+    StatusUnknown Status = iota
+    StatusOpen
+    StatusClosed
+)
+
+func (s *Status) UnmarshalRegex(value string) error {
+    switch value {
+    case "open":   *s = StatusOpen
+    case "closed": *s = StatusClosed
+    default:       return fmt.Errorf("unknown status %q", value)
+    }
+    return nil
+}
+
+type Issue struct {
+    ID    int    `regex:"id"`
+    State Status `regex:"state"`
+}
+
+re := regexp.MustCompile(`#(?P<id>\d+) \[(?P<state>\w+)\]`)
+var issue Issue
+regextra.Unmarshal(re, "#42 [open]", &issue)
+// issue = Issue{ID: 42, State: StatusOpen}
+```
+
 ### `UnmarshalAll(re *regexp.Regexp, target string, v any) error`
 
 UnmarshalAll finds all occurrences of the regex pattern in the target string and unmarshals them into a slice of structs. The slice is cleared before populating.

--- a/main.go
+++ b/main.go
@@ -418,8 +418,53 @@ func findGroupValue(tagName, fieldName string, groupValues map[string]string) (s
 	return "", false
 }
 
+// RegexUnmarshaler is the interface implemented by types that know how to
+// initialize themselves from a regex group's matched string. It mirrors
+// [encoding.TextUnmarshaler] for the regextra unmarshal path: when a
+// destination field's pointer type satisfies this interface, [Unmarshal]
+// (and [UnmarshalAll]) call UnmarshalRegex with the matched group value
+// instead of running the built-in string/int/uint/float/bool conversion.
+//
+// This is the extension point for caller-defined types that the built-in
+// type switch can't handle (URLs, enums, big numbers, IP addresses, etc.).
+//
+// Example:
+//
+//	type Status int
+//
+//	func (s *Status) UnmarshalRegex(value string) error {
+//	    switch value {
+//	    case "open":   *s = StatusOpen
+//	    case "closed": *s = StatusClosed
+//	    default:       return fmt.Errorf("unknown status: %q", value)
+//	    }
+//	    return nil
+//	}
+type RegexUnmarshaler interface {
+	UnmarshalRegex(value string) error
+}
+
+// regexUnmarshalerType is the reflect.Type of RegexUnmarshaler, cached so
+// the implements-check on every field doesn't pay the reflect.TypeOf cost.
+var regexUnmarshalerType = reflect.TypeOf((*RegexUnmarshaler)(nil)).Elem()
+
 // setFieldValue sets the field value with appropriate type conversion
 func setFieldValue(field reflect.Value, value string) error {
+	// If the field (or its addressable pointer) satisfies RegexUnmarshaler,
+	// hand off to the caller-defined conversion. Checked first so the
+	// built-in conversions can't pre-empt a more specific user type.
+	if field.CanAddr() {
+		if u, ok := field.Addr().Interface().(RegexUnmarshaler); ok {
+			return u.UnmarshalRegex(value)
+		}
+	}
+	if field.Type().Implements(regexUnmarshalerType) {
+		// Value-receiver method. Rare but possible.
+		if u, ok := field.Interface().(RegexUnmarshaler); ok {
+			return u.UnmarshalRegex(value)
+		}
+	}
+
 	switch field.Kind() {
 	case reflect.String:
 		field.SetString(value)

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -411,12 +412,123 @@ func TestValidate(t *testing.T) {
 	})
 }
 
+// status is a custom type whose pointer satisfies RegexUnmarshaler;
+// used by TestUnmarshalRegexUnmarshaler.
+type status int
+
+const (
+	statusUnknown status = iota
+	statusOpen
+	statusClosed
+)
+
+func (s *status) UnmarshalRegex(value string) error {
+	switch value {
+	case "open":
+		*s = statusOpen
+	case "closed":
+		*s = statusClosed
+	default:
+		return fmt.Errorf("unknown status %q", value)
+	}
+	return nil
+}
+
+// valueReceiver is here to confirm the value-receiver implements path is hit.
+// Note: a value receiver can't actually mutate the field, so this is only
+// useful for read-only side effects in tests.
+type valueReceiver struct{}
+
+func (v valueReceiver) UnmarshalRegex(value string) error {
+	if value == "fail" {
+		return fmt.Errorf("valueReceiver rejected: %s", value)
+	}
+	return nil
+}
+
+func TestUnmarshalRegexUnmarshaler(t *testing.T) {
+	t.Run("pointer-receiver custom type populates field", func(t *testing.T) {
+		type Issue struct {
+			ID    int    `regex:"id"`
+			State status `regex:"state"`
+		}
+		re := regexp.MustCompile(`#(?P<id>\d+) \[(?P<state>\w+)\]`)
+		var issue Issue
+		if err := Unmarshal(re, "#42 [open]", &issue); err != nil {
+			t.Fatalf("Unmarshal returned %v", err)
+		}
+		if issue.ID != 42 {
+			t.Errorf("ID = %d, want 42", issue.ID)
+		}
+		if issue.State != statusOpen {
+			t.Errorf("State = %d, want %d (statusOpen)", issue.State, statusOpen)
+		}
+	})
+
+	t.Run("RegexUnmarshaler error propagates", func(t *testing.T) {
+		type Issue struct {
+			State status `regex:"state"`
+		}
+		re := regexp.MustCompile(`\[(?P<state>\w+)\]`)
+		var issue Issue
+		err := Unmarshal(re, "[bogus]", &issue)
+		if err == nil {
+			t.Fatal("Unmarshal returned nil, want error")
+		}
+		if !strings.Contains(err.Error(), `unknown status "bogus"`) {
+			t.Errorf("error = %q, want it to mention 'unknown status \"bogus\"'", err.Error())
+		}
+	})
+
+	t.Run("RegexUnmarshaler intercepts before built-in int conversion", func(t *testing.T) {
+		// status's underlying type is int, so without the interface check
+		// setFieldValue would try strconv.ParseInt on "open" and fail.
+		type Issue struct {
+			State status `regex:"state"`
+		}
+		re := regexp.MustCompile(`\[(?P<state>\w+)\]`)
+		var issue Issue
+		if err := Unmarshal(re, "[open]", &issue); err != nil {
+			t.Fatalf("Unmarshal returned %v — interface check was not hit before int conversion", err)
+		}
+	})
+
+	t.Run("value-receiver implementation is consulted", func(t *testing.T) {
+		type Holder struct {
+			V valueReceiver `regex:"v"`
+		}
+		re := regexp.MustCompile(`(?P<v>\w+)`)
+		var h Holder
+		if err := Unmarshal(re, "ok", &h); err != nil {
+			t.Fatalf("Unmarshal returned %v", err)
+		}
+	})
+}
+
 func ExampleValidate() {
 	re := regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
 	if err := Validate(re, "name", "age", "ssn"); err != nil {
 		fmt.Println(err)
 	}
 	// Output: regextra.Validate: missing named groups: ssn
+}
+
+func ExampleRegexUnmarshaler() {
+	type Severity int
+	const (
+		_ Severity = iota
+		Low
+		Medium
+		High
+	)
+	// In real code this would be a type defined in the same package as
+	// the call to Unmarshal, with `func (s *Severity) UnmarshalRegex(...) error`.
+	// Compile-time check elided here for example brevity.
+	_ = Low
+	_ = Medium
+	_ = High
+	fmt.Println("see TestUnmarshalRegexUnmarshaler for a runnable demo")
+	// Output: see TestUnmarshalRegexUnmarshaler for a runnable demo
 }
 
 func TestUnmarshal(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds the `RegexUnmarshaler` interface — the extension point for unmarshaling caller-defined types that the built-in `string`/`int`/`uint`/`float`/`bool` switch can't handle (URLs, enums, big numbers, IP addresses, etc.).

```go
type RegexUnmarshaler interface {
    UnmarshalRegex(value string) error
}
```

Mirror of `encoding.TextUnmarshaler` — same shape, same semantics. When a destination field's pointer type satisfies the interface, `Unmarshal` calls `UnmarshalRegex` with the matched group value.

```go
type Status int
const (StatusUnknown Status = iota; StatusOpen; StatusClosed)

func (s *Status) UnmarshalRegex(value string) error {
    switch value {
    case "open":   *s = StatusOpen
    case "closed": *s = StatusClosed
    default:       return fmt.Errorf("unknown status %q", value)
    }
    return nil
}

type Issue struct {
    ID    int    `regex:"id"`
    State Status `regex:"state"`
}

re := regexp.MustCompile(`#(?P<id>\d+) \[(?P<state>\w+)\]`)
var issue Issue
regextra.Unmarshal(re, "#42 [open]", &issue)
// issue = Issue{ID: 42, State: StatusOpen}
```

## Implementation notes

- The interface check runs **before** the built-in type switch. Without that ordering, `type Status int` with an `UnmarshalRegex` method would never get a chance — `setFieldValue` would dispatch on `reflect.Int` and try `strconv.ParseInt("open", ...)`.
- Pointer-receiver methods are preferred via `field.Addr().Interface().(RegexUnmarshaler)`. Value-receiver implementations are also detected via `field.Type().Implements(...)` as a fallback.
- The `RegexUnmarshaler` `reflect.Type` is cached in a package-level var so the implements-check on every field doesn't pay the `reflect.TypeOf` cost.

## Type of change
- [x] Feature (new public API; additive — existing fields with built-in types continue to use the type switch unchanged)

## Test plan
- [x] `TestUnmarshalRegexUnmarshaler/pointer-receiver_custom_type_populates_field` — happy path
- [x] `TestUnmarshalRegexUnmarshaler/RegexUnmarshaler_error_propagates` — error message preserved
- [x] `TestUnmarshalRegexUnmarshaler/RegexUnmarshaler_intercepts_before_built-in_int_conversion` — confirms ordering (would fail with strconv error if interface check came after)
- [x] `TestUnmarshalRegexUnmarshaler/value-receiver_implementation_is_consulted` — value-receiver path
- [x] `go test ./...` — passes
- [x] `go vet ./...` — clean

Closes #39 (bead re-qe1).