### PR TITLE
feat: support time.Time and time.Duration in Unmarshal

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ if err := regextra.Validate(re, "name", "age", "ssn"); err != nil {
 
 Unmarshal regex matches into a struct with automatic type conversion. Similar to `json.Unmarshal`, but for regex patterns.
 
-**Supported field types:** `string`, `int`, `int8`, `int16`, `int32`, `int64`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `float32`, `float64`, `bool`
+**Supported field types:** `string`, `int`, `int8`, `int16`, `int32`, `int64`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `float32`, `float64`, `bool`, `time.Time`, `time.Duration`. For `time.Time`, several common layouts are tried (RFC3339, RFC3339Nano, `2006-01-02 15:04:05`, `2006-01-02`, `15:04:05`); `time.Duration` is parsed via `time.ParseDuration`. For caller-defined types, implement [`RegexUnmarshaler`](#regexunmarshaler-interface).
 
 **Field mapping priority:**
 1. Struct tag `regex:"groupname"` if provided (highest priority)

--- a/main.go
+++ b/main.go
@@ -21,7 +21,44 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
+
+// Cached reflect.Type values for the time types we special-case.
+// Comparing reflect.Type by equality is faster than rebuilding via
+// reflect.TypeOf on every field, and the resulting code is also clearer.
+var (
+	timeTimeType     = reflect.TypeOf(time.Time{})
+	timeDurationType = reflect.TypeOf(time.Duration(0))
+)
+
+// timeLayouts is the ordered set of layouts tried when parsing a string
+// into a time.Time field. The first layout that yields a non-error wins.
+// RFC3339 (and its nano variant) come first because they're the most
+// common in logs and APIs; the date / datetime / time-only forms cover
+// human-readable inputs without time zones.
+var timeLayouts = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	time.DateTime, // "2006-01-02 15:04:05"
+	time.DateOnly, // "2006-01-02"
+	time.TimeOnly, // "15:04:05"
+}
+
+// parseTime tries each layout in timeLayouts and returns the first success.
+func parseTime(value string) (time.Time, error) {
+	var firstErr error
+	for _, layout := range timeLayouts {
+		t, err := time.Parse(layout, value)
+		if err == nil {
+			return t, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return time.Time{}, firstErr
+}
 
 // FindNamed returns the value of the named capture group in the target string.
 // It returns the matched value and true if found, or empty string and false if not found.
@@ -450,9 +487,10 @@ var regexUnmarshalerType = reflect.TypeOf((*RegexUnmarshaler)(nil)).Elem()
 
 // setFieldValue sets the field value with appropriate type conversion
 func setFieldValue(field reflect.Value, value string) error {
-	// If the field (or its addressable pointer) satisfies RegexUnmarshaler,
-	// hand off to the caller-defined conversion. Checked first so the
-	// built-in conversions can't pre-empt a more specific user type.
+	// 1. RegexUnmarshaler comes first — caller-defined conversions beat
+	//    everything, including the stdlib special-cases below. A type
+	//    `type MyTime time.Time` with its own UnmarshalRegex must NOT be
+	//    pre-empted by the time.Time fast path.
 	if field.CanAddr() {
 		if u, ok := field.Addr().Interface().(RegexUnmarshaler); ok {
 			return u.UnmarshalRegex(value)
@@ -463,6 +501,27 @@ func setFieldValue(field reflect.Value, value string) error {
 		if u, ok := field.Interface().(RegexUnmarshaler); ok {
 			return u.UnmarshalRegex(value)
 		}
+	}
+
+	// 2. time.Time and time.Duration. Stdlib types we can't extend with
+	//    RegexUnmarshaler, but they dominate real-world parsing needs. Caught
+	//    by Type before the Kind switch because time.Duration's underlying
+	//    Kind is reflect.Int64.
+	switch field.Type() {
+	case timeTimeType:
+		t, err := parseTime(value)
+		if err != nil {
+			return fmt.Errorf("cannot convert %q to time.Time: %w", value, err)
+		}
+		field.Set(reflect.ValueOf(t))
+		return nil
+	case timeDurationType:
+		d, err := time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("cannot convert %q to time.Duration: %w", value, err)
+		}
+		field.Set(reflect.ValueOf(d))
+		return nil
 	}
 
 	switch field.Kind() {

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestFindNamed(t *testing.T) {
@@ -505,6 +506,110 @@ func TestUnmarshalRegexUnmarshaler(t *testing.T) {
 	})
 }
 
+func TestUnmarshalTimeTypes(t *testing.T) {
+	t.Run("time.Time RFC3339", func(t *testing.T) {
+		type Event struct {
+			TS time.Time `regex:"ts"`
+		}
+		re := regexp.MustCompile(`(?P<ts>\S+)`)
+		var ev Event
+		if err := Unmarshal(re, "2026-04-26T12:34:56Z", &ev); err != nil {
+			t.Fatalf("Unmarshal returned %v", err)
+		}
+		want, _ := time.Parse(time.RFC3339, "2026-04-26T12:34:56Z")
+		if !ev.TS.Equal(want) {
+			t.Errorf("TS = %v, want %v", ev.TS, want)
+		}
+	})
+
+	t.Run("time.Time DateTime fallback", func(t *testing.T) {
+		type Event struct {
+			TS time.Time `regex:"ts"`
+		}
+		re := regexp.MustCompile(`(?P<ts>.+)`)
+		var ev Event
+		if err := Unmarshal(re, "2026-04-26 12:34:56", &ev); err != nil {
+			t.Fatalf("Unmarshal returned %v", err)
+		}
+		if ev.TS.Year() != 2026 || ev.TS.Month() != time.April || ev.TS.Day() != 26 {
+			t.Errorf("TS = %v, want 2026-04-26 ...", ev.TS)
+		}
+	})
+
+	t.Run("time.Time DateOnly fallback", func(t *testing.T) {
+		type Event struct {
+			TS time.Time `regex:"ts"`
+		}
+		re := regexp.MustCompile(`(?P<ts>\S+)`)
+		var ev Event
+		if err := Unmarshal(re, "2026-04-26", &ev); err != nil {
+			t.Fatalf("Unmarshal returned %v", err)
+		}
+		if ev.TS.Year() != 2026 {
+			t.Errorf("Year = %d, want 2026", ev.TS.Year())
+		}
+	})
+
+	t.Run("time.Time unparseable returns error", func(t *testing.T) {
+		type Event struct {
+			TS time.Time `regex:"ts"`
+		}
+		re := regexp.MustCompile(`(?P<ts>.+)`)
+		var ev Event
+		err := Unmarshal(re, "definitely not a time", &ev)
+		if err == nil {
+			t.Fatal("Unmarshal returned nil, want error")
+		}
+		if !strings.Contains(err.Error(), "cannot convert") || !strings.Contains(err.Error(), "time.Time") {
+			t.Errorf("error = %q, want it to mention time.Time conversion failure", err.Error())
+		}
+	})
+
+	t.Run("time.Duration", func(t *testing.T) {
+		type Span struct {
+			D time.Duration `regex:"d"`
+		}
+		re := regexp.MustCompile(`(?P<d>\S+)`)
+		var sp Span
+		if err := Unmarshal(re, "1h30m", &sp); err != nil {
+			t.Fatalf("Unmarshal returned %v", err)
+		}
+		want := 90 * time.Minute
+		if sp.D != want {
+			t.Errorf("D = %v, want %v", sp.D, want)
+		}
+	})
+
+	t.Run("time.Duration unparseable returns error", func(t *testing.T) {
+		type Span struct {
+			D time.Duration `regex:"d"`
+		}
+		re := regexp.MustCompile(`(?P<d>\S+)`)
+		var sp Span
+		err := Unmarshal(re, "notaduration", &sp)
+		if err == nil {
+			t.Fatal("Unmarshal returned nil, want error")
+		}
+		if !strings.Contains(err.Error(), "cannot convert") || !strings.Contains(err.Error(), "time.Duration") {
+			t.Errorf("error = %q, want it to mention time.Duration conversion failure", err.Error())
+		}
+	})
+
+	t.Run("time.Duration is matched by Type, not by Int64 kind", func(t *testing.T) {
+		// time.Duration's underlying type is int64. Without the type-based
+		// match before the kind switch, "1h30m" would fall into reflect.Int64
+		// and strconv.ParseInt would reject it.
+		type Span struct {
+			D time.Duration `regex:"d"`
+		}
+		re := regexp.MustCompile(`(?P<d>\S+)`)
+		var sp Span
+		if err := Unmarshal(re, "5s", &sp); err != nil {
+			t.Fatalf("Unmarshal returned %v — Type-based match did not pre-empt Int64 kind", err)
+		}
+	})
+}
+
 func ExampleValidate() {
 	re := regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
 	if err := Validate(re, "name", "age", "ssn"); err != nil {
@@ -529,6 +634,18 @@ func ExampleRegexUnmarshaler() {
 	_ = High
 	fmt.Println("see TestUnmarshalRegexUnmarshaler for a runnable demo")
 	// Output: see TestUnmarshalRegexUnmarshaler for a runnable demo
+}
+
+func ExampleUnmarshal_timeTypes() {
+	type Event struct {
+		Started time.Time     `regex:"start"`
+		Took    time.Duration `regex:"took"`
+	}
+	re := regexp.MustCompile(`(?P<start>\S+)\s+\((?P<took>\S+)\)`)
+	var ev Event
+	_ = Unmarshal(re, "2026-04-26T12:34:56Z (1h30m)", &ev)
+	fmt.Printf("%s for %s\n", ev.Started.Format(time.RFC3339), ev.Took)
+	// Output: 2026-04-26T12:34:56Z for 1h30m0s
 }
 
 func TestUnmarshal(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds `time.Time` and `time.Duration` to the set of field types `Unmarshal` (and `UnmarshalAll`) understands. Today these fall through to `unsupported field type` and force callers into a manual two-step parse.

```go
type Event struct {
    Started time.Time     `regex:"start"`
    Took    time.Duration `regex:"took"`
}
re := regexp.MustCompile(`(?P<start>\S+)\s+\((?P<took>\S+)\)`)
var ev Event
regextra.Unmarshal(re, "2026-04-26T12:34:56Z (1h30m)", &ev)
// ev.Started = 2026-04-26 12:34:56 UTC
// ev.Took    = 1h30m0s
```

## Need a layout this PR doesn't try? Use `RegexUnmarshaler`

For locale-specific layouts, custom delimiters, non-RFC3339 timezone formats, or anything else not covered by the default fallback list, the documented escape hatch is the `RegexUnmarshaler` interface from #61:

```go
type ApacheTime time.Time

func (t *ApacheTime) UnmarshalRegex(value string) error {
    parsed, err := time.Parse("02/Jan/2006:15:04:05 -0700", value)
    if err != nil { return err }
    *t = ApacheTime(parsed)
    return nil
}

type LogLine struct {
    Timestamp ApacheTime `regex:"ts"`
    // ...
}
```

This is type-safe, explicit, and — unlike a global "set my preferred layouts" knob — race-free across packages that import each other. Per-field `regex:"ts,layout=..."` struct-tag override is tracked separately in `re-ttl` and bundles with the `default=` tag refactor (`re-qzg`) so the tag-options parser change happens once.

## Layouts tried by default for `time.Time`

In order — first non-error wins:

| Layout | Example |
|---|---|
| `time.RFC3339Nano` | `2026-04-26T12:34:56.123456789Z` |
| `time.RFC3339` | `2026-04-26T12:34:56Z` |
| `time.DateTime` | `2026-04-26 12:34:56` |
| `time.DateOnly` | `2026-04-26` |
| `time.TimeOnly` | `15:04:05` |

`time.Duration` is parsed via `time.ParseDuration` (the stdlib's `1h30m45s` syntax — same as `flag.Duration`).

## Implementation note: dispatch order matters

`setFieldValue` now runs three checks in order, before the existing kind switch:

1. **`RegexUnmarshaler` first** — caller-defined conversions beat everything, including the stdlib special-cases below. A type `type MyTime time.Time` with its own `UnmarshalRegex` must NOT be pre-empted by the time.Time fast path.
2. **`time.Time` and `time.Duration` second** — stdlib types we can't extend with `RegexUnmarshaler`. Caught by Type before the Kind switch because `time.Duration`'s underlying Kind is `reflect.Int64`; without the type check, `strconv.ParseInt("1h30m", 10, 64)` would reject the input before `time.ParseDuration` ever sees it.
3. **Kind switch** — built-in primitives (`string`, `int*`, `uint*`, `float*`, `bool`).

A test (`time.Duration is matched by Type, not by Int64 kind`) explicitly asserts ordering #2 — fail-loudly if a future refactor moves the kind switch above the type check.

## Type of change
- [x] Feature (new types in the existing Unmarshal type-conversion surface; additive — no signature changes, no behavior changes for existing field types)

## Test plan
- [x] `TestUnmarshalTimeTypes` covers seven cases: RFC3339 happy path, DateTime / DateOnly fallbacks, unparseable error message format, time.Duration happy path, time.Duration error, and the Type-vs-kind ordering invariant
- [x] `ExampleUnmarshal_timeTypes` renders on pkg.go.dev
- [x] `go test ./...` — passes
- [x] `go vet ./...` — clean
- [x] Rebased onto `main` after `feat/regex-unmarshaler` (#61) landed; conflicts in `setFieldValue` resolved by ordering RegexUnmarshaler check before the time-types special-case

## Out of scope (tracked separately)

- **Per-field layout override via struct tag** (`regex:"ts,layout=2006-01-02"`) — tracked in `re-ttl`. Bundles with `re-qzg` (default values) since both need the same tag-options parser change.
- **Time zone handling beyond what the chosen layout encodes** — covered by `RegexUnmarshaler`; see example above.

Closes #32 (bead re-5r4).