### PR TITLE
feat: support pointer fields in Unmarshal

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ if err := regextra.Validate(re, "name", "age", "ssn"); err != nil {
 
 Unmarshal regex matches into a struct with automatic type conversion. Similar to `json.Unmarshal`, but for regex patterns.
 
-**Supported field types:** `string`, `int`, `int8`, `int16`, `int32`, `int64`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `float32`, `float64`, `bool`, `time.Time`, `time.Duration`. For `time.Time`, several common layouts are tried (RFC3339, RFC3339Nano, `2006-01-02 15:04:05`, `2006-01-02`, `15:04:05`); `time.Duration` is parsed via `time.ParseDuration`. For caller-defined types, implement [`RegexUnmarshaler`](#regexunmarshaler-interface).
+**Supported field types:** `string`, `int`, `int8`, `int16`, `int32`, `int64`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `float32`, `float64`, `bool`, `time.Time`, `time.Duration`. Pointer-to-any-of-the-above is also supported — nil pointers are allocated, non-nil pointers are reused (pointee overwritten). For `time.Time`, several common layouts are tried (RFC3339, RFC3339Nano, `2006-01-02 15:04:05`, `2006-01-02`, `15:04:05`); `time.Duration` is parsed via `time.ParseDuration`. For caller-defined types, implement [`RegexUnmarshaler`](#regexunmarshaler-interface).
 
 **Field mapping priority:**
 1. Struct tag `regex:"groupname"` if provided (highest priority)

--- a/main.go
+++ b/main.go
@@ -487,10 +487,26 @@ var regexUnmarshalerType = reflect.TypeOf((*RegexUnmarshaler)(nil)).Elem()
 
 // setFieldValue sets the field value with appropriate type conversion
 func setFieldValue(field reflect.Value, value string) error {
-	// 1. RegexUnmarshaler comes first — caller-defined conversions beat
-	//    everything, including the stdlib special-cases below. A type
-	//    `type MyTime time.Time` with its own UnmarshalRegex must NOT be
-	//    pre-empted by the time.Time fast path.
+	// 0. Pointer fields: allocate the pointee if nil, then either dispatch
+	//    on the pointer's own RegexUnmarshaler (the common case for
+	//    pointer-receiver methods) or recurse into the pointee for the
+	//    built-in type conversions. Single-level pointers only —
+	//    `**Foo` falls through to the recursive call which handles each
+	//    level of indirection until the base case.
+	if field.Kind() == reflect.Ptr {
+		if field.IsNil() {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+		if u, ok := field.Interface().(RegexUnmarshaler); ok {
+			return u.UnmarshalRegex(value)
+		}
+		return setFieldValue(field.Elem(), value)
+	}
+
+	// 1. RegexUnmarshaler comes first for non-pointer fields — caller-defined
+	//    conversions beat everything, including the stdlib special-cases
+	//    below. A type `type MyTime time.Time` with its own UnmarshalRegex
+	//    must NOT be pre-empted by the time.Time fast path.
 	if field.CanAddr() {
 		if u, ok := field.Addr().Interface().(RegexUnmarshaler); ok {
 			return u.UnmarshalRegex(value)

--- a/main_test.go
+++ b/main_test.go
@@ -648,6 +648,158 @@ func ExampleUnmarshal_timeTypes() {
 	// Output: 2026-04-26T12:34:56Z for 1h30m0s
 }
 
+func TestUnmarshalPointerFields(t *testing.T) {
+	t.Run("*string allocated and set", func(t *testing.T) {
+		type Holder struct {
+			S *string `regex:"s"`
+		}
+		re := regexp.MustCompile(`(?P<s>\w+)`)
+		var h Holder
+		if err := Unmarshal(re, "hello", &h); err != nil {
+			t.Fatalf("Unmarshal returned %v", err)
+		}
+		if h.S == nil {
+			t.Fatal("S is nil; pointer was not allocated")
+		}
+		if *h.S != "hello" {
+			t.Errorf("*S = %q, want %q", *h.S, "hello")
+		}
+	})
+
+	t.Run("*int allocated and set", func(t *testing.T) {
+		type Holder struct {
+			N *int `regex:"n"`
+		}
+		re := regexp.MustCompile(`(?P<n>\d+)`)
+		var h Holder
+		if err := Unmarshal(re, "42", &h); err != nil {
+			t.Fatalf("Unmarshal returned %v", err)
+		}
+		if h.N == nil || *h.N != 42 {
+			t.Errorf("*N = %v, want 42", h.N)
+		}
+	})
+
+	t.Run("*float64 allocated and set", func(t *testing.T) {
+		type Holder struct {
+			F *float64 `regex:"f"`
+		}
+		re := regexp.MustCompile(`(?P<f>\S+)`)
+		var h Holder
+		if err := Unmarshal(re, "3.14", &h); err != nil {
+			t.Fatalf("Unmarshal returned %v", err)
+		}
+		if h.F == nil || *h.F != 3.14 {
+			t.Errorf("*F = %v, want 3.14", h.F)
+		}
+	})
+
+	t.Run("*bool allocated and set", func(t *testing.T) {
+		type Holder struct {
+			B *bool `regex:"b"`
+		}
+		re := regexp.MustCompile(`(?P<b>\S+)`)
+		var h Holder
+		if err := Unmarshal(re, "true", &h); err != nil {
+			t.Fatalf("Unmarshal returned %v", err)
+		}
+		if h.B == nil || *h.B != true {
+			t.Errorf("*B = %v, want true", h.B)
+		}
+	})
+
+	t.Run("*time.Time allocated and set via the time-types path", func(t *testing.T) {
+		type Holder struct {
+			TS *time.Time `regex:"ts"`
+		}
+		re := regexp.MustCompile(`(?P<ts>\S+)`)
+		var h Holder
+		if err := Unmarshal(re, "2026-04-26T12:34:56Z", &h); err != nil {
+			t.Fatalf("Unmarshal returned %v", err)
+		}
+		if h.TS == nil {
+			t.Fatal("TS is nil; pointer was not allocated")
+		}
+		if h.TS.Year() != 2026 {
+			t.Errorf("TS.Year() = %d, want 2026", h.TS.Year())
+		}
+	})
+
+	t.Run("*time.Duration allocated and set", func(t *testing.T) {
+		type Holder struct {
+			D *time.Duration `regex:"d"`
+		}
+		re := regexp.MustCompile(`(?P<d>\S+)`)
+		var h Holder
+		if err := Unmarshal(re, "5s", &h); err != nil {
+			t.Fatalf("Unmarshal returned %v", err)
+		}
+		if h.D == nil || *h.D != 5*time.Second {
+			t.Errorf("*D = %v, want 5s", h.D)
+		}
+	})
+
+	t.Run("*RegexUnmarshaler dispatched on the pointer's own method", func(t *testing.T) {
+		type Holder struct {
+			S *status `regex:"s"`
+		}
+		re := regexp.MustCompile(`\[(?P<s>\w+)\]`)
+		var h Holder
+		if err := Unmarshal(re, "[open]", &h); err != nil {
+			t.Fatalf("Unmarshal returned %v", err)
+		}
+		if h.S == nil || *h.S != statusOpen {
+			t.Errorf("*S = %v, want statusOpen", h.S)
+		}
+	})
+
+	t.Run("non-nil pointer is not re-allocated; existing pointee overwritten", func(t *testing.T) {
+		type Holder struct {
+			N *int `regex:"n"`
+		}
+		re := regexp.MustCompile(`(?P<n>\d+)`)
+		preallocated := 999
+		h := Holder{N: &preallocated}
+		original := h.N
+		if err := Unmarshal(re, "42", &h); err != nil {
+			t.Fatalf("Unmarshal returned %v", err)
+		}
+		if h.N != original {
+			t.Errorf("pointer identity changed; expected the existing pointer to be reused")
+		}
+		if *h.N != 42 {
+			t.Errorf("*N = %d, want 42 (pointee should be overwritten)", *h.N)
+		}
+	})
+
+	t.Run("conversion error on pointer field is returned without partial state", func(t *testing.T) {
+		type Holder struct {
+			N *int `regex:"n"`
+		}
+		re := regexp.MustCompile(`(?P<n>\S+)`)
+		var h Holder
+		err := Unmarshal(re, "notanumber", &h)
+		if err == nil {
+			t.Fatal("Unmarshal returned nil, want error")
+		}
+		if !strings.Contains(err.Error(), "cannot convert") {
+			t.Errorf("error = %q, want it to mention conversion failure", err.Error())
+		}
+	})
+}
+
+func ExampleUnmarshal_pointerFields() {
+	type Result struct {
+		Name *string `regex:"name"`
+		Age  *int    `regex:"age"`
+	}
+	re := regexp.MustCompile(`(?P<name>\w+)\s+is\s+(?P<age>\d+)`)
+	var r Result
+	_ = Unmarshal(re, "Alice is 30", &r)
+	fmt.Printf("%s, %d\n", *r.Name, *r.Age)
+	// Output: Alice, 30
+}
+
 func TestUnmarshal(t *testing.T) {
 	t.Run("basic string fields", func(t *testing.T) {
 		type Person struct {


### PR DESCRIPTION
## Summary

`Unmarshal` (and `UnmarshalAll`) now handle pointer fields. Nil pointers are allocated on entry; non-nil pointers are reused with the pointee overwritten. Covers the optional-field idiom (`*string`, `*int`, `*time.Time`, …) without forcing callers to write a `RegexUnmarshaler` wrapper just to get nil-as-default semantics.

```go
type Result struct {
    Name *string `regex:"name"`
    Age  *int    `regex:"age"`
}
re := regexp.MustCompile(`(?P<name>\w+)\s+is\s+(?P<age>\d+)`)
var r Result
regextra.Unmarshal(re, "Alice is 30", &r)
// *r.Name = "Alice", *r.Age = 30
```

## What's supported

| Pointer type | Behavior |
|---|---|
| `*string`, `*int*`, `*uint*`, `*float*`, `*bool` | Alloc + recurse → kind switch |
| `*time.Time`, `*time.Duration` | Alloc + recurse → time-types fast path |
| `*T` where `*T` (or `T`) implements `RegexUnmarshaler` | Alloc + dispatch on the pointer's own method (no recursion) |
| `**T` (multi-level) | Falls through the recursive call but **not explicitly supported**; behavior subject to change |

## Implementation note

The pointer step runs **before** the existing RegexUnmarshaler / time-types / kind dispatch:

1. **Pointer dispatch (new)** — if `Kind() == Ptr`: allocate if nil; if the pointer satisfies `RegexUnmarshaler`, call it (covers pointer-receiver methods like `func (s *Status) UnmarshalRegex(...)`); otherwise recurse on `Elem()`.
2. RegexUnmarshaler check on the dereferenced value (for value-receiver methods).
3. time.Time / time.Duration type check.
4. Kind switch.

Non-nil pointers are reused — pointer identity is preserved (`pre := &x; Unmarshal(...); pre == r.Field` still holds). This matches stdlib precedent (`encoding/json` behaves the same way for pre-allocated destination fields).

## Type of change
- [x] Feature (new behavior on a previously-unsupported field shape; additive — no signature changes, existing field types unaffected)

## Test plan
- [x] `TestUnmarshalPointerFields` covers nine cases: `*string`, `*int`, `*float64`, `*bool`, `*time.Time`, `*time.Duration`, `*RegexUnmarshaler`, non-nil pointer reuse, and conversion-error propagation
- [x] `ExampleUnmarshal_pointerFields` renders on pkg.go.dev
- [x] `go test ./...` — passes
- [x] `go vet ./...` — clean

Closes #42 (bead re-2vo).