### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-26
+
+Additive minor release. No breaking changes — every existing field type, function signature, and tag form keeps working. New surface area in three buckets: extraction helpers, an extension point for caller-defined types, and richer `Unmarshal` field-type support.
+
+### Added
+
+- **`FindAllNamed(re, target, groupName) []string`** — collects every value of a single named group across all matches. Returns `nil` when the group is not declared on the regex; an empty slice when declared but no matches. Fills the gap between `FindNamed` (one match, one group) and `AllNamedGroups` (all matches, all groups). ([#58](https://github.com/Jecoms/regextra/pull/58))
+- **`Replace(re, target, replacements map[string]string) string`** — substitutes the matched span of each named capture group with the value from the map. Operates on every match in order; groups absent from the map pass through unchanged. ([#59](https://github.com/Jecoms/regextra/pull/59))
+- **`Validate(re, required ...string) error`** — returns an error listing required group names not declared on the regex. Init-time assertion that catches typos at startup instead of at the first mismatched request. ([#60](https://github.com/Jecoms/regextra/pull/60))
+- **`RegexUnmarshaler` interface** — mirror of `encoding.TextUnmarshaler` for the regextra unmarshal path. When a destination field's pointer type satisfies this interface, `Unmarshal` calls `UnmarshalRegex(value)` instead of running the built-in type switch. The extension point for caller-defined types (URLs, enums, big numbers, IP addresses, custom timestamp formats). ([#61](https://github.com/Jecoms/regextra/pull/61))
+- **`time.Time` and `time.Duration` field support in `Unmarshal`** — `time.Time` tries RFC3339Nano, RFC3339, DateTime, DateOnly, TimeOnly in order; `time.Duration` parses via `time.ParseDuration`. Caught by Type before the kind switch so `time.Duration`'s underlying `int64` doesn't pre-empt the duration parser. ([#62](https://github.com/Jecoms/regextra/pull/62))
+- **Pointer field support in `Unmarshal`** — nil pointers are allocated; non-nil pointers are reused with the pointee overwritten. Covers the optional-field idiom (`*string`, `*int`, `*time.Time`, …) without forcing a `RegexUnmarshaler` wrapper. Single-level pointers are the documented contract. ([#63](https://github.com/Jecoms/regextra/pull/63))
+- **Tag options: `default=<value>` and `layout=<go-time-layout>`** — `default=` substitutes when the named group is undeclared or its match is empty (goes through type conversion, so `default=100` works on `int` fields). `layout=` pins `time.Time` parsing to a specific layout for non-RFC3339 sources (Apache logs, locale-specific timestamps). Tag grammar is JSON-encoding-style: `regex:"name,key=value,key=value"`. ([#64](https://github.com/Jecoms/regextra/pull/64))
+
+### Changed
+
+- `setFieldValue` dispatch order is now: pointer → `RegexUnmarshaler` → `time.Time`/`time.Duration` Type match → kind switch. Ordering is intentional and asserted by tests — `RegexUnmarshaler` must come before `time.Time` so a `type MyTime time.Time` with its own `UnmarshalRegex` isn't pre-empted by the time-types fast path; the time-types Type match must come before the kind switch so `time.Duration`'s underlying `Int64` kind doesn't pre-empt `time.ParseDuration`.
+
+### Deprecated
+
+- _None._
+
+### Removed
+
+- _None._
+
+### Fixed
+
+- _None._
+
+### Security
+
+- _None._
+
 ## [0.3.2] - 2026-04-26
 
 ### Added


### PR DESCRIPTION
## Summary

Additive minor release. **No breaking changes** — every existing field type, function signature, and tag form keeps working.

Merging this PR fires the consolidated `auto-tag.yml` (shipped in v0.3.2): runs tests, pushes the `v0.4.0` tag, and publishes the GitHub Release in one workflow run.

## What changed since v0.3.2

### Added — extraction helpers

- `FindAllNamed(re, target, groupName) []string` ([#58](https://github.com/Jecoms/regextra/pull/58))
- `Replace(re, target, replacements map[string]string) string` ([#59](https://github.com/Jecoms/regextra/pull/59))
- `Validate(re, required ...string) error` ([#60](https://github.com/Jecoms/regextra/pull/60))

### Added — `Unmarshal` extensibility

- `RegexUnmarshaler` interface — `UnmarshalRegex(value string) error`. The extension point for caller-defined types. ([#61](https://github.com/Jecoms/regextra/pull/61))

### Added — `Unmarshal` field-type support

- `time.Time` (multi-layout fallback) and `time.Duration` ([#62](https://github.com/Jecoms/regextra/pull/62))
- Pointer fields (`*string`, `*int`, `*time.Time`, …) ([#63](https://github.com/Jecoms/regextra/pull/63))
- Tag options: `default=<value>` and `layout=<go-time-layout>` ([#64](https://github.com/Jecoms/regextra/pull/64))

### Changed

- `setFieldValue` dispatch order: pointer → RegexUnmarshaler → time-types Type match → kind switch. Ordering is asserted by tests.

## Type of change
- [x] Feature (additive minor release; no breaking changes)

## Test plan
- [x] CHANGELOG entries verified against the merged PR list since v0.3.2
- [x] All seven feature PRs landed green on CI before this release branch was cut
- [ ] On merge: `auto-tag.yml` runs → `v0.4.0` tag pushed → GitHub Release published automatically (cascade fix from v0.3.2)
- [ ] pkg.go.dev shows v0.4.0 within minutes of the tag push

## Follow-ups planned for v0.4.0 → v0.5.0 transition

These have beads filed:
- `re-vse` — split `main.go` into topical files (single rename PR; main.go + main_test.go are growing past the comfortable single-file size)
- `re-rrm` — benchmarks for the Unmarshal hot path (foundation for measuring the v0.5.0 Decoder[T] win)
- `re-tan` — deeper fuzz invariants beyond no-panic (round-trip, contract preservation)
- _Plus_ a small `test:` PR to merge `fuzz_test.go` into `main_test.go`

Then v0.5.0 opens with `Compile[T]` / `Decoder[T]` (`re-3e2`) and `Iter[T]` (`re-dej`) — the architectural perf win + iterator API.