### PR TITLE
test(perf): add Unmarshal hot-path benchmarks

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -2,6 +2,7 @@ package regextra
 
 import (
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 )
@@ -183,11 +184,8 @@ func BenchmarkUnmarshalAll_logLines(b *testing.B) {
 		Msg   string `regex:"msg"`
 	}
 	re := regexp.MustCompile(`\[(?P<level>\w+)\] (?P<msg>[^\n]+)`)
-	// Build 100 lines of input
-	var target string
-	for i := 0; i < 100; i++ {
-		target += "[info] message body here\n"
-	}
+	// 100 lines of input
+	target := strings.Repeat("[info] message body here\n", 100)
 	b.ReportAllocs()
 	for b.Loop() {
 		var lines []line

--- a/bench_test.go
+++ b/bench_test.go
@@ -24,6 +24,8 @@ import (
 
 var benchFindRe = regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
 
+// BenchmarkFindNamed measures the single-group, single-match extraction path —
+// the cheapest function in the package and the baseline for everything else.
 func BenchmarkFindNamed(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
@@ -31,6 +33,8 @@ func BenchmarkFindNamed(b *testing.B) {
 	}
 }
 
+// BenchmarkNamedGroups measures the all-groups-as-map path. The map allocation
+// dominates the cost vs. FindNamed.
 func BenchmarkNamedGroups(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
@@ -38,6 +42,8 @@ func BenchmarkNamedGroups(b *testing.B) {
 	}
 }
 
+// BenchmarkFindAllNamed measures the all-matches projection of one named group.
+// Allocation scales with match count.
 func BenchmarkFindAllNamed(b *testing.B) {
 	re := regexp.MustCompile(`(?P<word>\S+)`)
 	target := "alpha beta gamma delta epsilon zeta eta theta"
@@ -49,6 +55,9 @@ func BenchmarkFindAllNamed(b *testing.B) {
 
 // ── Replace ───────────────────────────────────────────────────────────────────
 
+// BenchmarkReplace measures the substitution path: scan all matches, sort
+// per-match group spans, build the output string. Three matches in the input
+// to exercise the multi-match branch.
 func BenchmarkReplace(b *testing.B) {
 	re := regexp.MustCompile(`(?P<user>\w+)@(?P<domain>[\w.]+)`)
 	target := "alice@example.com bob@other.org carol@third.net"
@@ -65,6 +74,9 @@ func BenchmarkReplace(b *testing.B) {
 // pointer / RegexUnmarshaler / time.Time fast-paths — measures the cost of
 // the four dispatch checks added in v0.4.0 against a "boring" struct.
 
+// benchSimple is a 3-field destination struct using only the kind-switch
+// branches of setFieldValue: string, int, bool. The benchmark measures that
+// path's per-call cost.
 type benchSimple struct {
 	Name   string `regex:"name"`
 	Age    int    `regex:"age"`
@@ -73,6 +85,8 @@ type benchSimple struct {
 
 var benchSimpleRe = regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+) (?P<active>\w+)`)
 
+// BenchmarkUnmarshal_simpleStruct measures the kind-switch path with no fast
+// paths hit. Establishes the baseline that v0.5.0's Decoder[T] should beat.
 func BenchmarkUnmarshal_simpleStruct(b *testing.B) {
 	target := "Alice is 30 true"
 	b.ReportAllocs()
@@ -90,11 +104,14 @@ func BenchmarkUnmarshal_simpleStruct(b *testing.B) {
 // per field: one Kind() check + one IsNil() check + one allocation per nil
 // pointer.
 
+// benchPointers exercises the pointer dispatch step (allocate-if-nil + recurse).
 type benchPointers struct {
 	Name *string `regex:"name"`
 	Age  *int    `regex:"age"`
 }
 
+// BenchmarkUnmarshal_pointerFields measures the cost of the pointer dispatch
+// step plus the per-field allocation that nil pointers incur.
 func BenchmarkUnmarshal_pointerFields(b *testing.B) {
 	target := "Alice is 30"
 	re := regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
@@ -113,6 +130,8 @@ func BenchmarkUnmarshal_pointerFields(b *testing.B) {
 // The fallback time.Parse loop runs only on first-layout-miss; this benchmark
 // uses RFC3339 input so the first layout matches.
 
+// benchTime exercises the time-types fast paths (Type-equality match before
+// the kind switch).
 type benchTime struct {
 	TS   time.Time     `regex:"ts"`
 	Took time.Duration `regex:"took"`
@@ -120,6 +139,9 @@ type benchTime struct {
 
 var benchTimeRe = regexp.MustCompile(`(?P<ts>\S+) \((?P<took>\S+)\)`)
 
+// BenchmarkUnmarshal_timeFields measures the time.Time + time.Duration fast
+// paths. Input is RFC3339 so the first layout in the fallback list matches —
+// worst-case (last-layout-wins) is not measured here.
 func BenchmarkUnmarshal_timeFields(b *testing.B) {
 	target := "2026-04-26T12:34:56Z (1h30m)"
 	b.ReportAllocs()
@@ -136,6 +158,8 @@ func BenchmarkUnmarshal_timeFields(b *testing.B) {
 // Exercises the interface-dispatch step. The test type is intentionally simple
 // so the benchmark measures dispatch cost, not the body of UnmarshalRegex.
 
+// benchStatus is a caller-defined enum whose pointer satisfies
+// RegexUnmarshaler. Used to measure the interface-dispatch step.
 type benchStatus int
 
 const (
@@ -144,6 +168,8 @@ const (
 	benchStatusClosed
 )
 
+// UnmarshalRegex maps the matched string to a benchStatus value. Body kept
+// minimal so the benchmark measures dispatch cost, not parse cost.
 func (s *benchStatus) UnmarshalRegex(value string) error {
 	switch value {
 	case "open":
@@ -156,12 +182,16 @@ func (s *benchStatus) UnmarshalRegex(value string) error {
 	return nil
 }
 
+// benchCustom is the destination struct for the RegexUnmarshaler benchmark.
 type benchCustom struct {
 	State benchStatus `regex:"state"`
 }
 
 var benchCustomRe = regexp.MustCompile(`\[(?P<state>\w+)\]`)
 
+// BenchmarkUnmarshal_customUnmarshaler measures the RegexUnmarshaler interface
+// dispatch step in setFieldValue. The custom UnmarshalRegex body is trivial so
+// the timing reflects dispatch overhead rather than user-defined work.
 func BenchmarkUnmarshal_customUnmarshaler(b *testing.B) {
 	target := "[open]"
 	b.ReportAllocs()
@@ -178,6 +208,10 @@ func BenchmarkUnmarshal_customUnmarshaler(b *testing.B) {
 // The realistic hot path for log parsers. Measures per-line amortized cost
 // across a batch — the metric Decoder[T] (re-3e2) is designed to improve.
 
+// BenchmarkUnmarshalAll_logLines measures amortized per-line decode cost
+// across a 100-line batch. This is the hot path Decoder[T] (re-3e2) is
+// designed to optimize — each iteration today rebuilds the reflect plan
+// from scratch.
 func BenchmarkUnmarshalAll_logLines(b *testing.B) {
 	type line struct {
 		Level string `regex:"level"`

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,198 @@
+package regextra
+
+import (
+	"regexp"
+	"testing"
+	"time"
+)
+
+// Benchmarks for the hot paths users actually call. The goal is twofold:
+//
+//  1. Establish a baseline against which v0.5.0's Decoder[T] (re-3e2) can
+//     demonstrate its caching win.
+//  2. Catch regressions on the existing free-function path. v0.4.0 added four
+//     dispatch checks at the top of setFieldValue (pointer, RegexUnmarshaler,
+//     time.Time, time.Duration) — keep the absolute cost visible so future
+//     additions are vetted against a budget rather than guessed about.
+//
+// Run with:
+//
+//	go test -bench=. -benchmem -run=^$ ./...
+
+// ── Find / NamedGroups baseline ───────────────────────────────────────────────
+
+var benchFindRe = regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
+
+func BenchmarkFindNamed(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = FindNamed(benchFindRe, "Alice is 30", "name")
+	}
+}
+
+func BenchmarkNamedGroups(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = NamedGroups(benchFindRe, "Alice is 30")
+	}
+}
+
+func BenchmarkFindAllNamed(b *testing.B) {
+	re := regexp.MustCompile(`(?P<word>\S+)`)
+	target := "alpha beta gamma delta epsilon zeta eta theta"
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = FindAllNamed(re, target, "word")
+	}
+}
+
+// ── Replace ───────────────────────────────────────────────────────────────────
+
+func BenchmarkReplace(b *testing.B) {
+	re := regexp.MustCompile(`(?P<user>\w+)@(?P<domain>[\w.]+)`)
+	target := "alice@example.com bob@other.org carol@third.net"
+	repl := map[string]string{"domain": "redacted"}
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = Replace(re, target, repl)
+	}
+}
+
+// ── Unmarshal: simple struct (string + int + bool) ───────────────────────────
+//
+// Baseline for the most common shape. Hits the kind switch path with no
+// pointer / RegexUnmarshaler / time.Time fast-paths — measures the cost of
+// the four dispatch checks added in v0.4.0 against a "boring" struct.
+
+type benchSimple struct {
+	Name   string `regex:"name"`
+	Age    int    `regex:"age"`
+	Active bool   `regex:"active"`
+}
+
+var benchSimpleRe = regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+) (?P<active>\w+)`)
+
+func BenchmarkUnmarshal_simpleStruct(b *testing.B) {
+	target := "Alice is 30 true"
+	b.ReportAllocs()
+	for b.Loop() {
+		var s benchSimple
+		if err := Unmarshal(benchSimpleRe, target, &s); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// ── Unmarshal: pointer fields ────────────────────────────────────────────────
+//
+// Exercises the new pointer-dispatch step (allocate-if-nil + recurse). Cost
+// per field: one Kind() check + one IsNil() check + one allocation per nil
+// pointer.
+
+type benchPointers struct {
+	Name *string `regex:"name"`
+	Age  *int    `regex:"age"`
+}
+
+func BenchmarkUnmarshal_pointerFields(b *testing.B) {
+	target := "Alice is 30"
+	re := regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
+	b.ReportAllocs()
+	for b.Loop() {
+		var p benchPointers
+		if err := Unmarshal(re, target, &p); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// ── Unmarshal: time.Time + time.Duration ─────────────────────────────────────
+//
+// Hits the time-types fast path (Type-equality match before the Kind switch).
+// The fallback time.Parse loop runs only on first-layout-miss; this benchmark
+// uses RFC3339 input so the first layout matches.
+
+type benchTime struct {
+	TS   time.Time     `regex:"ts"`
+	Took time.Duration `regex:"took"`
+}
+
+var benchTimeRe = regexp.MustCompile(`(?P<ts>\S+) \((?P<took>\S+)\)`)
+
+func BenchmarkUnmarshal_timeFields(b *testing.B) {
+	target := "2026-04-26T12:34:56Z (1h30m)"
+	b.ReportAllocs()
+	for b.Loop() {
+		var t benchTime
+		if err := Unmarshal(benchTimeRe, target, &t); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// ── Unmarshal: RegexUnmarshaler-implementing field ───────────────────────────
+//
+// Exercises the interface-dispatch step. The test type is intentionally simple
+// so the benchmark measures dispatch cost, not the body of UnmarshalRegex.
+
+type benchStatus int
+
+const (
+	benchStatusUnknown benchStatus = iota
+	benchStatusOpen
+	benchStatusClosed
+)
+
+func (s *benchStatus) UnmarshalRegex(value string) error {
+	switch value {
+	case "open":
+		*s = benchStatusOpen
+	case "closed":
+		*s = benchStatusClosed
+	default:
+		*s = benchStatusUnknown
+	}
+	return nil
+}
+
+type benchCustom struct {
+	State benchStatus `regex:"state"`
+}
+
+var benchCustomRe = regexp.MustCompile(`\[(?P<state>\w+)\]`)
+
+func BenchmarkUnmarshal_customUnmarshaler(b *testing.B) {
+	target := "[open]"
+	b.ReportAllocs()
+	for b.Loop() {
+		var c benchCustom
+		if err := Unmarshal(benchCustomRe, target, &c); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// ── UnmarshalAll: 100 log-line iteration ─────────────────────────────────────
+//
+// The realistic hot path for log parsers. Measures per-line amortized cost
+// across a batch — the metric Decoder[T] (re-3e2) is designed to improve.
+
+func BenchmarkUnmarshalAll_logLines(b *testing.B) {
+	type line struct {
+		Level string `regex:"level"`
+		Msg   string `regex:"msg"`
+	}
+	re := regexp.MustCompile(`\[(?P<level>\w+)\] (?P<msg>[^\n]+)`)
+	// Build 100 lines of input
+	var target string
+	for i := 0; i < 100; i++ {
+		target += "[info] message body here\n"
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		var lines []line
+		if err := UnmarshalAll(re, target, &lines); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `bench_test.go` with nine benchmarks covering the hot paths users actually call. Two purposes:

1. **Baseline for v0.5.0's `Decoder[T]` (`re-3e2`)** — that work caches the reflect plan per type and should show 2–10× speedups over per-call `Unmarshal`. Need numbers to prove that.
2. **Regression catch on the existing free-function path.** v0.4.0 added four dispatch checks at the top of `setFieldValue` (pointer / RegexUnmarshaler / time.Time / time.Duration). Now the absolute cost is visible.

## Initial numbers (Apple M4, Go 1.24, `-benchtime=2s`)

| Benchmark | ns/op | B/op | allocs/op |
|-----------|------:|-----:|----------:|
| `FindNamed` | 138 | 112 | 2 |
| `NamedGroups` | 209 | 451 | 4 |
| `FindAllNamed` | 1,003 | 884 | 18 |
| `Replace` | 893 | 869 | 14 |
| `Unmarshal_simpleStruct` | 499 | 209 | 6 |
| `Unmarshal_pointerFields` | 398 | 185 | 7 |
| `Unmarshal_timeFields` | 939 | 209 | 7 |
| `Unmarshal_customUnmarshaler` | 197 | 56 | 3 |
| `UnmarshalAll_logLines` (100 lines) | 47,971 | 29,983 | 608 |

Three things worth noting:

- **`Unmarshal_simpleStruct` ≈ 500 ns/op** for a 3-field struct — that's roughly 165 ns/field of reflect overhead on top of the regex match. Decoder[T] should drop this 3–5×.
- **`Unmarshal_pointerFields` faster than simple struct** (398 vs 499 ns) because the pointer test only has 2 fields vs 3. Per-field cost is comparable.
- **`UnmarshalAll_logLines` allocates ~6 allocs per line** — most of that is the per-match `groupValues` map + reflect.Value construction. Decoder[T] should approximately halve allocs by reusing the field-plan.

Concrete numbers to compare against in the v0.5.0 PR.

## Type of change
- [x] Test (no source change, no behavior change)

## Test plan
- [x] All 9 benchmarks compile and run
- [x] No external dependencies added
- [x] `go test ./...` (non-bench) unaffected
- [x] `go vet ./...` clean

## Out of scope (follow-up)

- **CI integration.** Running `go test -bench=. -benchmem -run='^$'` on push-to-main only (not per-PR — bench data is too noisy for green/red gating on a per-commit basis), uploading results as an artifact, comparing against the previous main run via `benchstat`. Worth its own focused PR; tracked as a follow-up to re-rrm rather than gating this one.

Closes #(re-rrm's GH mirror).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added benchmark suite to measure performance of named group matching, string replacement, and struct unmarshalling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->