### PR TITLE
test: convert tests to package regextra_test (external)

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -101,7 +101,7 @@ func BenchmarkUnmarshal_simpleStruct(b *testing.B) {
 
 // benchSimpleDecoder is the same struct decoded via a precompiled Decoder.
 // Compare against BenchmarkUnmarshal_simpleStruct to see the v0.5.0 win.
-var benchSimpleDecoder = MustCompile[benchSimple](`(?P<name>\w+) is (?P<age>\d+) (?P<active>\w+)`)
+var benchSimpleDecoder = rx.MustCompile[benchSimple](`(?P<name>\w+) is (?P<age>\d+) (?P<active>\w+)`)
 
 // BenchmarkDecoder_simpleStruct.One measures the same shape as
 // BenchmarkUnmarshal_simpleStruct via a precompiled Decoder. Both reuse

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,6 +1,7 @@
-package regextra
+package regextra_test
 
 import (
+	rx "github.com/jecoms/regextra"
 	"regexp"
 	"strings"
 	"testing"
@@ -29,7 +30,7 @@ var benchFindRe = regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
 func BenchmarkFindNamed(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
-		_, _ = FindNamed(benchFindRe, "Alice is 30", "name")
+		_, _ = rx.FindNamed(benchFindRe, "Alice is 30", "name")
 	}
 }
 
@@ -38,7 +39,7 @@ func BenchmarkFindNamed(b *testing.B) {
 func BenchmarkNamedGroups(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
-		_ = NamedGroups(benchFindRe, "Alice is 30")
+		_ = rx.NamedGroups(benchFindRe, "Alice is 30")
 	}
 }
 
@@ -49,7 +50,7 @@ func BenchmarkFindAllNamed(b *testing.B) {
 	target := "alpha beta gamma delta epsilon zeta eta theta"
 	b.ReportAllocs()
 	for b.Loop() {
-		_ = FindAllNamed(re, target, "word")
+		_ = rx.FindAllNamed(re, target, "word")
 	}
 }
 
@@ -64,7 +65,7 @@ func BenchmarkReplace(b *testing.B) {
 	repl := map[string]string{"domain": "redacted"}
 	b.ReportAllocs()
 	for b.Loop() {
-		_ = Replace(re, target, repl)
+		_ = rx.Replace(re, target, repl)
 	}
 }
 
@@ -92,7 +93,7 @@ func BenchmarkUnmarshal_simpleStruct(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		var s benchSimple
-		if err := Unmarshal(benchSimpleRe, target, &s); err != nil {
+		if err := rx.Unmarshal(benchSimpleRe, target, &s); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -137,7 +138,7 @@ func BenchmarkUnmarshal_pointerFields(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		var p benchPointers
-		if err := Unmarshal(re, target, &p); err != nil {
+		if err := rx.Unmarshal(re, target, &p); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -166,7 +167,7 @@ func BenchmarkUnmarshal_timeFields(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		var t benchTime
-		if err := Unmarshal(benchTimeRe, target, &t); err != nil {
+		if err := rx.Unmarshal(benchTimeRe, target, &t); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -216,7 +217,7 @@ func BenchmarkUnmarshal_customUnmarshaler(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		var c benchCustom
-		if err := Unmarshal(benchCustomRe, target, &c); err != nil {
+		if err := rx.Unmarshal(benchCustomRe, target, &c); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -242,7 +243,7 @@ func BenchmarkUnmarshalAll_logLines(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		var lines []line
-		if err := UnmarshalAll(re, target, &lines); err != nil {
+		if err := rx.UnmarshalAll(re, target, &lines); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/regextra_test.go
+++ b/regextra_test.go
@@ -1,7 +1,8 @@
-package regextra
+package regextra_test
 
 import (
 	"fmt"
+	rx "github.com/jecoms/regextra"
 	"reflect"
 	"regexp"
 	"testing"
@@ -60,7 +61,7 @@ func TestFindNamed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			re := regexp.MustCompile(tt.pattern)
-			got, found := FindNamed(re, tt.target, tt.groupName)
+			got, found := rx.FindNamed(re, tt.target, tt.groupName)
 			if got != tt.want {
 				t.Errorf("FindNamed() got = %v, want %v", got, tt.want)
 			}
@@ -105,7 +106,7 @@ func TestNamedGroups(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			re := regexp.MustCompile(tt.pattern)
-			if got := NamedGroups(re, tt.target); !reflect.DeepEqual(got, tt.want) {
+			if got := rx.NamedGroups(re, tt.target); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NamedGroups() = %v, want %v", got, tt.want)
 			}
 		})
@@ -114,7 +115,7 @@ func TestNamedGroups(t *testing.T) {
 
 func ExampleFindNamed() {
 	re := regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
-	name, ok := FindNamed(re, "Alice 30", "name")
+	name, ok := rx.FindNamed(re, "Alice 30", "name")
 	fmt.Printf("%s: %v\n", name, ok)
 	// Output: Alice: true
 }
@@ -166,7 +167,7 @@ func TestFindAllNamed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			re := regexp.MustCompile(tt.pattern)
-			got := FindAllNamed(re, tt.target, tt.group)
+			got := rx.FindAllNamed(re, tt.target, tt.group)
 			if tt.want == nil {
 				if got != nil {
 					t.Errorf("FindAllNamed = %v, want nil", got)
@@ -182,14 +183,14 @@ func TestFindAllNamed(t *testing.T) {
 
 func ExampleFindAllNamed() {
 	re := regexp.MustCompile(`(?P<word>\S+)`)
-	words := FindAllNamed(re, "alpha beta gamma", "word")
+	words := rx.FindAllNamed(re, "alpha beta gamma", "word")
 	fmt.Println(words)
 	// Output: [alpha beta gamma]
 }
 
 func ExampleNamedGroups() {
 	re := regexp.MustCompile(`(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})`)
-	groups := NamedGroups(re, "Date: 2025-10-04")
+	groups := rx.NamedGroups(re, "Date: 2025-10-04")
 
 	// Note: map iteration order is not guaranteed, so we print sorted
 	keys := []string{"year", "month", "day"}
@@ -258,7 +259,7 @@ func TestAllNamedGroups(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			re := regexp.MustCompile(tt.pattern)
-			got := AllNamedGroups(re, tt.target)
+			got := rx.AllNamedGroups(re, tt.target)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("AllNamedGroups() = %v, want %v", got, tt.want)
 			}
@@ -268,7 +269,7 @@ func TestAllNamedGroups(t *testing.T) {
 
 func ExampleAllNamedGroups() {
 	re := regexp.MustCompile(`(?P<word>\w+) (?P<word>\w+) (?P<word>\w+)`)
-	allGroups := AllNamedGroups(re, "one two three")
+	allGroups := rx.AllNamedGroups(re, "one two three")
 
 	fmt.Printf("word: %v\n", allGroups["word"])
 	// Output: word: [one two three]
@@ -342,7 +343,7 @@ func TestReplace(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			re := regexp.MustCompile(tt.pattern)
-			got := Replace(re, tt.target, tt.repl)
+			got := rx.Replace(re, tt.target, tt.repl)
 			if got != tt.want {
 				t.Errorf("Replace = %q, want %q", got, tt.want)
 			}
@@ -352,7 +353,7 @@ func TestReplace(t *testing.T) {
 
 func ExampleReplace() {
 	re := regexp.MustCompile(`(?P<user>\w+)@(?P<domain>[\w.]+)`)
-	out := Replace(re, "alice@example.com bob@other.org", map[string]string{
+	out := rx.Replace(re, "alice@example.com bob@other.org", map[string]string{
 		"domain": "redacted",
 	})
 	fmt.Println(out)
@@ -363,25 +364,25 @@ func TestValidate(t *testing.T) {
 	re := regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
 
 	t.Run("all declared returns nil", func(t *testing.T) {
-		if err := Validate(re, "name", "age"); err != nil {
+		if err := rx.Validate(re, "name", "age"); err != nil {
 			t.Errorf("Validate returned %v, want nil", err)
 		}
 	})
 
 	t.Run("subset of declared returns nil", func(t *testing.T) {
-		if err := Validate(re, "name"); err != nil {
+		if err := rx.Validate(re, "name"); err != nil {
 			t.Errorf("Validate returned %v, want nil", err)
 		}
 	})
 
 	t.Run("empty required returns nil", func(t *testing.T) {
-		if err := Validate(re); err != nil {
+		if err := rx.Validate(re); err != nil {
 			t.Errorf("Validate returned %v, want nil", err)
 		}
 	})
 
 	t.Run("single missing reports it", func(t *testing.T) {
-		err := Validate(re, "name", "ssn")
+		err := rx.Validate(re, "name", "ssn")
 		if err == nil {
 			t.Fatal("Validate returned nil, want error")
 		}
@@ -392,7 +393,7 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("multiple missing preserves request order", func(t *testing.T) {
-		err := Validate(re, "ssn", "age", "email", "name", "phone")
+		err := rx.Validate(re, "ssn", "age", "email", "name", "phone")
 		if err == nil {
 			t.Fatal("Validate returned nil, want error")
 		}
@@ -404,7 +405,7 @@ func TestValidate(t *testing.T) {
 
 	t.Run("regex with no named groups, all required missing", func(t *testing.T) {
 		bare := regexp.MustCompile(`\w+`)
-		err := Validate(bare, "name")
+		err := rx.Validate(bare, "name")
 		if err == nil {
 			t.Fatal("Validate returned nil, want error")
 		}
@@ -415,7 +416,7 @@ func TestValidate(t *testing.T) {
 // used by TestUnmarshalRegexUnmarshaler.
 func ExampleValidate() {
 	re := regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
-	if err := Validate(re, "name", "age", "ssn"); err != nil {
+	if err := rx.Validate(re, "name", "age", "ssn"); err != nil {
 		fmt.Println(err)
 	}
 	// Output: regextra.Validate: missing named groups: ssn
@@ -442,12 +443,12 @@ func FuzzFindNamed(f *testing.F) {
 	re := regexp.MustCompile(`(?P<word>\S+)\s+(?P<num>\d+)`)
 	f.Fuzz(func(t *testing.T, target string) {
 		// Should not panic for any input.
-		got, ok := FindNamed(re, target, "word")
+		got, ok := rx.FindNamed(re, target, "word")
 		if !ok && got != "" {
 			t.Fatalf("FindNamed contract violated: ok=false but got=%q (want empty)", got)
 		}
 		// Group name that doesn't exist must always return ("", false).
-		miss, missOk := FindNamed(re, target, "definitelyNotThere")
+		miss, missOk := rx.FindNamed(re, target, "definitelyNotThere")
 		if miss != "" || missOk {
 			t.Fatalf("missing group name should return (\"\", false), got (%q, %v)", miss, missOk)
 		}
@@ -466,7 +467,7 @@ func FuzzNamedGroups(f *testing.F) {
 	declared := map[string]bool{"word": true, "num": true}
 
 	f.Fuzz(func(t *testing.T, target string) {
-		groups := NamedGroups(re, target)
+		groups := rx.NamedGroups(re, target)
 		if groups == nil {
 			t.Fatalf("NamedGroups returned nil; contract requires non-nil map")
 		}

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -18,11 +18,20 @@ const (
 	statusClosed
 )
 
+const (
+	stateOpen   = "open"
+	stateClosed = "closed"
+)
+
+// aliceFixture is the canonical fixture string used across input-validation
+// tests. Defined as a const to keep the goconst linter happy.
+const aliceFixture = "Alice"
+
 func (s *status) UnmarshalRegex(value string) error {
 	switch value {
-	case "open":
+	case stateOpen:
 		*s = statusOpen
-	case "closed":
+	case stateClosed:
 		*s = statusClosed
 	default:
 		return fmt.Errorf("unknown status %q", value)
@@ -536,8 +545,8 @@ func TestUnmarshal(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unmarshal() error = %v", err)
 		}
-		if person.Name != "Alice" {
-			t.Errorf("Name = %q, want %q", person.Name, "Alice")
+		if person.Name != aliceFixture {
+			t.Errorf("Name = %q, want %q", person.Name, aliceFixture)
 		}
 		if person.Age != "30" {
 			t.Errorf("Age = %q, want %q", person.Age, "30")
@@ -641,7 +650,7 @@ func TestUnmarshal(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>\w+)`)
 		var person Person
-		err := rx.Unmarshal(re, "Alice", person) // Not a pointer
+		err := rx.Unmarshal(re, aliceFixture, person) // Not a pointer
 		if err == nil {
 			t.Error("Unmarshal() expected error for non-pointer, got nil")
 		}
@@ -653,7 +662,7 @@ func TestUnmarshal(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>\w+)`)
 		var person *Person
-		err := rx.Unmarshal(re, "Alice", person) // Nil pointer
+		err := rx.Unmarshal(re, aliceFixture, person) // Nil pointer
 		if err == nil {
 			t.Error("Unmarshal() expected error for nil pointer, got nil")
 		}
@@ -662,7 +671,7 @@ func TestUnmarshal(t *testing.T) {
 	t.Run("error on pointer to non-struct", func(t *testing.T) {
 		re := regexp.MustCompile(`(?P<name>\w+)`)
 		var name string
-		err := rx.Unmarshal(re, "Alice", &name) // Pointer to string, not struct
+		err := rx.Unmarshal(re, aliceFixture, &name) // Pointer to string, not struct
 		if err == nil {
 			t.Error("Unmarshal() expected error for pointer to non-struct, got nil")
 		}
@@ -776,7 +785,7 @@ func TestUnmarshalAll(t *testing.T) {
 		if len(people) != 2 {
 			t.Fatalf("len(people) = %d, want 2", len(people))
 		}
-		if people[0].Name != "Alice" || people[0].Age != 30 {
+		if people[0].Name != aliceFixture || people[0].Age != 30 {
 			t.Errorf("people[0] = %+v, want {Name:Alice Age:30}", people[0])
 		}
 		if people[1].Name != "Bob" || people[1].Age != 25 {
@@ -848,7 +857,7 @@ func TestUnmarshalAll(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>\w+)`)
 		var people []Person
-		err := rx.UnmarshalAll(re, "Alice", people) // Not a pointer
+		err := rx.UnmarshalAll(re, aliceFixture, people) // Not a pointer
 		if err == nil {
 			t.Error("UnmarshalAll() expected error for non-pointer, got nil")
 		}
@@ -860,7 +869,7 @@ func TestUnmarshalAll(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>\w+)`)
 		var people *[]Person
-		err := rx.UnmarshalAll(re, "Alice", people) // Nil pointer
+		err := rx.UnmarshalAll(re, aliceFixture, people) // Nil pointer
 		if err == nil {
 			t.Error("UnmarshalAll() expected error for nil pointer, got nil")
 		}
@@ -872,7 +881,7 @@ func TestUnmarshalAll(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>\w+)`)
 		var person Person
-		err := rx.UnmarshalAll(re, "Alice", &person) // Pointer to struct, not slice
+		err := rx.UnmarshalAll(re, aliceFixture, &person) // Pointer to struct, not slice
 		if err == nil {
 			t.Error("UnmarshalAll() expected error for pointer to non-slice, got nil")
 		}
@@ -881,7 +890,7 @@ func TestUnmarshalAll(t *testing.T) {
 	t.Run("error on slice of non-structs", func(t *testing.T) {
 		re := regexp.MustCompile(`(?P<name>\w+)`)
 		var names []string
-		err := rx.UnmarshalAll(re, "Alice", &names) // Slice of strings, not structs
+		err := rx.UnmarshalAll(re, aliceFixture, &names) // Slice of strings, not structs
 		if err == nil {
 			t.Error("UnmarshalAll() expected error for slice of non-structs, got nil")
 		}

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1,7 +1,8 @@
-package regextra
+package regextra_test
 
 import (
 	"fmt"
+	rx "github.com/jecoms/regextra"
 	"reflect"
 	"regexp"
 	"strings"
@@ -49,7 +50,7 @@ func TestUnmarshalRegexUnmarshaler(t *testing.T) {
 		}
 		re := regexp.MustCompile(`#(?P<id>\d+) \[(?P<state>\w+)\]`)
 		var issue Issue
-		if err := Unmarshal(re, "#42 [open]", &issue); err != nil {
+		if err := rx.Unmarshal(re, "#42 [open]", &issue); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		if issue.ID != 42 {
@@ -66,7 +67,7 @@ func TestUnmarshalRegexUnmarshaler(t *testing.T) {
 		}
 		re := regexp.MustCompile(`\[(?P<state>\w+)\]`)
 		var issue Issue
-		err := Unmarshal(re, "[bogus]", &issue)
+		err := rx.Unmarshal(re, "[bogus]", &issue)
 		if err == nil {
 			t.Fatal("Unmarshal returned nil, want error")
 		}
@@ -83,7 +84,7 @@ func TestUnmarshalRegexUnmarshaler(t *testing.T) {
 		}
 		re := regexp.MustCompile(`\[(?P<state>\w+)\]`)
 		var issue Issue
-		if err := Unmarshal(re, "[open]", &issue); err != nil {
+		if err := rx.Unmarshal(re, "[open]", &issue); err != nil {
 			t.Fatalf("Unmarshal returned %v — interface check was not hit before int conversion", err)
 		}
 	})
@@ -94,7 +95,7 @@ func TestUnmarshalRegexUnmarshaler(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<v>\w+)`)
 		var h Holder
-		if err := Unmarshal(re, "ok", &h); err != nil {
+		if err := rx.Unmarshal(re, "ok", &h); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 	})
@@ -107,7 +108,7 @@ func TestUnmarshalTimeTypes(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<ts>\S+)`)
 		var ev Event
-		if err := Unmarshal(re, "2026-04-26T12:34:56Z", &ev); err != nil {
+		if err := rx.Unmarshal(re, "2026-04-26T12:34:56Z", &ev); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		want, _ := time.Parse(time.RFC3339, "2026-04-26T12:34:56Z")
@@ -122,7 +123,7 @@ func TestUnmarshalTimeTypes(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<ts>.+)`)
 		var ev Event
-		if err := Unmarshal(re, "2026-04-26 12:34:56", &ev); err != nil {
+		if err := rx.Unmarshal(re, "2026-04-26 12:34:56", &ev); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		if ev.TS.Year() != 2026 || ev.TS.Month() != time.April || ev.TS.Day() != 26 {
@@ -136,7 +137,7 @@ func TestUnmarshalTimeTypes(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<ts>\S+)`)
 		var ev Event
-		if err := Unmarshal(re, "2026-04-26", &ev); err != nil {
+		if err := rx.Unmarshal(re, "2026-04-26", &ev); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		if ev.TS.Year() != 2026 {
@@ -150,7 +151,7 @@ func TestUnmarshalTimeTypes(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<ts>.+)`)
 		var ev Event
-		err := Unmarshal(re, "definitely not a time", &ev)
+		err := rx.Unmarshal(re, "definitely not a time", &ev)
 		if err == nil {
 			t.Fatal("Unmarshal returned nil, want error")
 		}
@@ -165,7 +166,7 @@ func TestUnmarshalTimeTypes(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<d>\S+)`)
 		var sp Span
-		if err := Unmarshal(re, "1h30m", &sp); err != nil {
+		if err := rx.Unmarshal(re, "1h30m", &sp); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		want := 90 * time.Minute
@@ -180,7 +181,7 @@ func TestUnmarshalTimeTypes(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<d>\S+)`)
 		var sp Span
-		err := Unmarshal(re, "notaduration", &sp)
+		err := rx.Unmarshal(re, "notaduration", &sp)
 		if err == nil {
 			t.Fatal("Unmarshal returned nil, want error")
 		}
@@ -198,7 +199,7 @@ func TestUnmarshalTimeTypes(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<d>\S+)`)
 		var sp Span
-		if err := Unmarshal(re, "5s", &sp); err != nil {
+		if err := rx.Unmarshal(re, "5s", &sp); err != nil {
 			t.Fatalf("Unmarshal returned %v — Type-based match did not pre-empt Int64 kind", err)
 		}
 	})
@@ -229,49 +230,9 @@ func ExampleUnmarshal_timeTypes() {
 	}
 	re := regexp.MustCompile(`(?P<start>\S+)\s+\((?P<took>\S+)\)`)
 	var ev Event
-	_ = Unmarshal(re, "2026-04-26T12:34:56Z (1h30m)", &ev)
+	_ = rx.Unmarshal(re, "2026-04-26T12:34:56Z (1h30m)", &ev)
 	fmt.Printf("%s for %s\n", ev.Started.Format(time.RFC3339), ev.Took)
 	// Output: 2026-04-26T12:34:56Z for 1h30m0s
-}
-
-func TestParseFieldTag(t *testing.T) {
-	type T struct {
-		A string `regex:"a"`
-		B string `regex:"b,default=fallback"`
-		C string `regex:"c,default=,layout=2006"`
-		D string `regex:"d,layout=2006-01-02"`
-		E string `regex:""`
-		F string `regex:"-"`
-		G string
-		H string `regex:"h,unknown=stuff,layout=Z"`
-	}
-	tt := reflect.TypeOf(T{})
-	cases := []struct {
-		fieldName string
-		wantName  string
-		wantOpts  map[string]string
-	}{
-		{"A", "a", nil},
-		{"B", "b", map[string]string{"default": "fallback"}},
-		{"C", "c", map[string]string{"default": "", "layout": "2006"}},
-		{"D", "d", map[string]string{"layout": "2006-01-02"}},
-		{"E", "", nil},
-		{"F", "", nil},
-		{"G", "", nil},
-		{"H", "h", map[string]string{"unknown": "stuff", "layout": "Z"}},
-	}
-	for _, c := range cases {
-		t.Run(c.fieldName, func(t *testing.T) {
-			f, _ := tt.FieldByName(c.fieldName)
-			gotName, gotOpts := parseFieldTag(f)
-			if gotName != c.wantName {
-				t.Errorf("name = %q, want %q", gotName, c.wantName)
-			}
-			if !reflect.DeepEqual(gotOpts, c.wantOpts) {
-				t.Errorf("opts = %v, want %v", gotOpts, c.wantOpts)
-			}
-		})
-	}
 }
 
 func TestUnmarshalDefault(t *testing.T) {
@@ -283,7 +244,7 @@ func TestUnmarshalDefault(t *testing.T) {
 		const wantName = "Mallory"
 		re := regexp.MustCompile(`(?P<name>\w+)`)
 		var p Person
-		if err := Unmarshal(re, wantName, &p); err != nil {
+		if err := rx.Unmarshal(re, wantName, &p); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		if p.Name != wantName {
@@ -302,7 +263,7 @@ func TestUnmarshalDefault(t *testing.T) {
 		// match for the named group.
 		re := regexp.MustCompile(`^(?P<title>[A-Z]?)\.?$`)
 		var p Person
-		if err := Unmarshal(re, ".", &p); err != nil {
+		if err := rx.Unmarshal(re, ".", &p); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		if p.Title != "N/A" {
@@ -316,7 +277,7 @@ func TestUnmarshalDefault(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<role>\w+)`)
 		var p Person
-		if err := Unmarshal(re, "admin", &p); err != nil {
+		if err := rx.Unmarshal(re, "admin", &p); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		if p.Role != "admin" {
@@ -330,7 +291,7 @@ func TestUnmarshalDefault(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<other>\w+)`)
 		var l Limits
-		if err := Unmarshal(re, "ignored", &l); err != nil {
+		if err := rx.Unmarshal(re, "ignored", &l); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		if l.Max != 100 {
@@ -344,7 +305,7 @@ func TestUnmarshalDefault(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<other>\w+)`)
 		var l Limits
-		err := Unmarshal(re, "ignored", &l)
+		err := rx.Unmarshal(re, "ignored", &l)
 		if err == nil {
 			t.Fatal("Unmarshal returned nil, want error from default conversion")
 		}
@@ -361,7 +322,7 @@ func TestUnmarshalLayoutOverride(t *testing.T) {
 		}
 		re := regexp.MustCompile(`\[(?P<ts>[^\]]+)\]`)
 		var l Log
-		if err := Unmarshal(re, "[26/Apr/2026:12:34:56 -0500]", &l); err != nil {
+		if err := rx.Unmarshal(re, "[26/Apr/2026:12:34:56 -0500]", &l); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		if l.TS.Year() != 2026 || l.TS.Month() != time.April || l.TS.Day() != 26 {
@@ -375,7 +336,7 @@ func TestUnmarshalLayoutOverride(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<ts>\S+)`)
 		var l Log
-		err := Unmarshal(re, "not-a-date", &l)
+		err := rx.Unmarshal(re, "not-a-date", &l)
 		if err == nil {
 			t.Fatal("Unmarshal returned nil, want error")
 		}
@@ -392,7 +353,7 @@ func TestUnmarshalLayoutOverride(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<ts>\S+)`)
 		var l Log
-		err := Unmarshal(re, "2026-04-26", &l)
+		err := rx.Unmarshal(re, "2026-04-26", &l)
 		if err == nil {
 			t.Fatal("Unmarshal returned nil; layout override should not fall back to DateOnly")
 		}
@@ -406,7 +367,7 @@ func ExampleUnmarshal_defaultAndLayout() {
 	}
 	re := regexp.MustCompile(`\[(?P<ts>[^\]]+)\]\s*(?P<other>.*)`)
 	var l LogLine
-	_ = Unmarshal(re, "[26/Apr/2026:12:34:56 -0500] something happened", &l)
+	_ = rx.Unmarshal(re, "[26/Apr/2026:12:34:56 -0500] something happened", &l)
 	fmt.Printf("%s @ %s\n", l.Level, l.TS.Format("2006-01-02"))
 	// Output: info @ 2026-04-26
 }
@@ -418,7 +379,7 @@ func TestUnmarshalPointerFields(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<s>\w+)`)
 		var h Holder
-		if err := Unmarshal(re, "hello", &h); err != nil {
+		if err := rx.Unmarshal(re, "hello", &h); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		if h.S == nil {
@@ -435,7 +396,7 @@ func TestUnmarshalPointerFields(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<n>\d+)`)
 		var h Holder
-		if err := Unmarshal(re, "42", &h); err != nil {
+		if err := rx.Unmarshal(re, "42", &h); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		if h.N == nil || *h.N != 42 {
@@ -449,7 +410,7 @@ func TestUnmarshalPointerFields(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<f>\S+)`)
 		var h Holder
-		if err := Unmarshal(re, "3.14", &h); err != nil {
+		if err := rx.Unmarshal(re, "3.14", &h); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		if h.F == nil || *h.F != 3.14 {
@@ -463,7 +424,7 @@ func TestUnmarshalPointerFields(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<b>\S+)`)
 		var h Holder
-		if err := Unmarshal(re, "true", &h); err != nil {
+		if err := rx.Unmarshal(re, "true", &h); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		if h.B == nil || *h.B != true {
@@ -477,7 +438,7 @@ func TestUnmarshalPointerFields(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<ts>\S+)`)
 		var h Holder
-		if err := Unmarshal(re, "2026-04-26T12:34:56Z", &h); err != nil {
+		if err := rx.Unmarshal(re, "2026-04-26T12:34:56Z", &h); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		if h.TS == nil {
@@ -494,7 +455,7 @@ func TestUnmarshalPointerFields(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<d>\S+)`)
 		var h Holder
-		if err := Unmarshal(re, "5s", &h); err != nil {
+		if err := rx.Unmarshal(re, "5s", &h); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		if h.D == nil || *h.D != 5*time.Second {
@@ -508,7 +469,7 @@ func TestUnmarshalPointerFields(t *testing.T) {
 		}
 		re := regexp.MustCompile(`\[(?P<s>\w+)\]`)
 		var h Holder
-		if err := Unmarshal(re, "[open]", &h); err != nil {
+		if err := rx.Unmarshal(re, "[open]", &h); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		if h.S == nil || *h.S != statusOpen {
@@ -524,7 +485,7 @@ func TestUnmarshalPointerFields(t *testing.T) {
 		preallocated := 999
 		h := Holder{N: &preallocated}
 		original := h.N
-		if err := Unmarshal(re, "42", &h); err != nil {
+		if err := rx.Unmarshal(re, "42", &h); err != nil {
 			t.Fatalf("Unmarshal returned %v", err)
 		}
 		if h.N != original {
@@ -541,7 +502,7 @@ func TestUnmarshalPointerFields(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<n>\S+)`)
 		var h Holder
-		err := Unmarshal(re, "notanumber", &h)
+		err := rx.Unmarshal(re, "notanumber", &h)
 		if err == nil {
 			t.Fatal("Unmarshal returned nil, want error")
 		}
@@ -558,7 +519,7 @@ func ExampleUnmarshal_pointerFields() {
 	}
 	re := regexp.MustCompile(`(?P<name>\w+)\s+is\s+(?P<age>\d+)`)
 	var r Result
-	_ = Unmarshal(re, "Alice is 30", &r)
+	_ = rx.Unmarshal(re, "Alice is 30", &r)
 	fmt.Printf("%s, %d\n", *r.Name, *r.Age)
 	// Output: Alice, 30
 }
@@ -571,7 +532,7 @@ func TestUnmarshal(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
 		var person Person
-		err := Unmarshal(re, "Alice is 30", &person)
+		err := rx.Unmarshal(re, "Alice is 30", &person)
 		if err != nil {
 			t.Fatalf("Unmarshal() error = %v", err)
 		}
@@ -590,7 +551,7 @@ func TestUnmarshal(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
 		var person Person
-		err := Unmarshal(re, "Bob is 25", &person)
+		err := rx.Unmarshal(re, "Bob is 25", &person)
 		if err != nil {
 			t.Fatalf("Unmarshal() error = %v", err)
 		}
@@ -609,7 +570,7 @@ func TestUnmarshal(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>\w+) costs \$(?P<price>[\d.]+)`)
 		var product Product
-		err := Unmarshal(re, "Widget costs $19.99", &product)
+		err := rx.Unmarshal(re, "Widget costs $19.99", &product)
 		if err != nil {
 			t.Fatalf("Unmarshal() error = %v", err)
 		}
@@ -628,7 +589,7 @@ func TestUnmarshal(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<user>\w+)@(?P<domain>[\w.]+)`)
 		var email Email
-		err := Unmarshal(re, "alice@example.com", &email)
+		err := rx.Unmarshal(re, "alice@example.com", &email)
 		if err != nil {
 			t.Fatalf("Unmarshal() error = %v", err)
 		}
@@ -647,7 +608,7 @@ func TestUnmarshal(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<username>\w+) (?P<age>\d+)`)
 		var data Data
-		err := Unmarshal(re, "john 42", &data)
+		err := rx.Unmarshal(re, "john 42", &data)
 		if err != nil {
 			t.Fatalf("Unmarshal() error = %v", err)
 		}
@@ -665,7 +626,7 @@ func TestUnmarshal(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>[a-z]+)`) // Only lowercase letters
 		var person Person
-		err := Unmarshal(re, "123", &person)
+		err := rx.Unmarshal(re, "123", &person)
 		if err != nil {
 			t.Errorf("Unmarshal() error = %v, want nil", err)
 		}
@@ -680,7 +641,7 @@ func TestUnmarshal(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>\w+)`)
 		var person Person
-		err := Unmarshal(re, "Alice", person) // Not a pointer
+		err := rx.Unmarshal(re, "Alice", person) // Not a pointer
 		if err == nil {
 			t.Error("Unmarshal() expected error for non-pointer, got nil")
 		}
@@ -692,7 +653,7 @@ func TestUnmarshal(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>\w+)`)
 		var person *Person
-		err := Unmarshal(re, "Alice", person) // Nil pointer
+		err := rx.Unmarshal(re, "Alice", person) // Nil pointer
 		if err == nil {
 			t.Error("Unmarshal() expected error for nil pointer, got nil")
 		}
@@ -701,7 +662,7 @@ func TestUnmarshal(t *testing.T) {
 	t.Run("error on pointer to non-struct", func(t *testing.T) {
 		re := regexp.MustCompile(`(?P<name>\w+)`)
 		var name string
-		err := Unmarshal(re, "Alice", &name) // Pointer to string, not struct
+		err := rx.Unmarshal(re, "Alice", &name) // Pointer to string, not struct
 		if err == nil {
 			t.Error("Unmarshal() expected error for pointer to non-struct, got nil")
 		}
@@ -714,7 +675,7 @@ func TestUnmarshal(t *testing.T) {
 		}
 		re := regexp.MustCompile(`enabled=(?P<enabled>\w+) debug=(?P<debug>\w+)`)
 		var config Config
-		err := Unmarshal(re, "enabled=yes debug=true", &config)
+		err := rx.Unmarshal(re, "enabled=yes debug=true", &config)
 		if err != nil {
 			t.Fatalf("Unmarshal() error = %v", err)
 		}
@@ -733,7 +694,7 @@ func TestUnmarshal(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<public>\w+) (?P<private>\w+)`)
 		var data Data
-		err := Unmarshal(re, "hello world", &data)
+		err := rx.Unmarshal(re, "hello world", &data)
 		if err != nil {
 			t.Fatalf("Unmarshal() error = %v", err)
 		}
@@ -753,7 +714,7 @@ func TestUnmarshal(t *testing.T) {
 		// Pattern has both "value" and "count" groups
 		re := regexp.MustCompile(`value=(?P<value>\w+) count=(?P<count>\d+)`)
 		var data Data
-		err := Unmarshal(re, "value=hello count=42", &data)
+		err := rx.Unmarshal(re, "value=hello count=42", &data)
 		if err != nil {
 			t.Fatalf("Unmarshal() error = %v", err)
 		}
@@ -772,7 +733,7 @@ func ExampleUnmarshal() {
 
 	re := regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+) years old`)
 	var person Person
-	err := Unmarshal(re, "Alice is 30 years old", &person)
+	err := rx.Unmarshal(re, "Alice is 30 years old", &person)
 	if err != nil {
 		fmt.Println("Error:", err)
 		return
@@ -790,7 +751,7 @@ func ExampleUnmarshal_structTags() {
 
 	re := regexp.MustCompile(`(?P<user>\w+)@(?P<domain>[\w.]+)`)
 	var email Email
-	err := Unmarshal(re, "alice@example.com", &email)
+	err := rx.Unmarshal(re, "alice@example.com", &email)
 	if err != nil {
 		fmt.Println("Error:", err)
 		return
@@ -808,7 +769,7 @@ func TestUnmarshalAll(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
 		var people []Person
-		err := UnmarshalAll(re, "Alice is 30 and Bob is 25", &people)
+		err := rx.UnmarshalAll(re, "Alice is 30 and Bob is 25", &people)
 		if err != nil {
 			t.Fatalf("UnmarshalAll() error = %v", err)
 		}
@@ -829,7 +790,7 @@ func TestUnmarshalAll(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>[a-z]+)`)
 		people := []Person{{Name: "existing"}}
-		err := UnmarshalAll(re, "123", &people)
+		err := rx.UnmarshalAll(re, "123", &people)
 		if err != nil {
 			t.Fatalf("UnmarshalAll() error = %v", err)
 		}
@@ -845,7 +806,7 @@ func TestUnmarshalAll(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<user>\w+)@(?P<domain>[\w.]+)`)
 		var emails []Email
-		err := UnmarshalAll(re, "Contact: alice@example.com", &emails)
+		err := rx.UnmarshalAll(re, "Contact: alice@example.com", &emails)
 		if err != nil {
 			t.Fatalf("UnmarshalAll() error = %v", err)
 		}
@@ -864,7 +825,7 @@ func TestUnmarshalAll(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>\w+):\$(?P<price>[\d.]+)`)
 		var products []Product
-		err := UnmarshalAll(re, "Items: Apple:$1.50 Banana:$0.75 Orange:$2.00", &products)
+		err := rx.UnmarshalAll(re, "Items: Apple:$1.50 Banana:$0.75 Orange:$2.00", &products)
 		if err != nil {
 			t.Fatalf("UnmarshalAll() error = %v", err)
 		}
@@ -887,7 +848,7 @@ func TestUnmarshalAll(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>\w+)`)
 		var people []Person
-		err := UnmarshalAll(re, "Alice", people) // Not a pointer
+		err := rx.UnmarshalAll(re, "Alice", people) // Not a pointer
 		if err == nil {
 			t.Error("UnmarshalAll() expected error for non-pointer, got nil")
 		}
@@ -899,7 +860,7 @@ func TestUnmarshalAll(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>\w+)`)
 		var people *[]Person
-		err := UnmarshalAll(re, "Alice", people) // Nil pointer
+		err := rx.UnmarshalAll(re, "Alice", people) // Nil pointer
 		if err == nil {
 			t.Error("UnmarshalAll() expected error for nil pointer, got nil")
 		}
@@ -911,7 +872,7 @@ func TestUnmarshalAll(t *testing.T) {
 		}
 		re := regexp.MustCompile(`(?P<name>\w+)`)
 		var person Person
-		err := UnmarshalAll(re, "Alice", &person) // Pointer to struct, not slice
+		err := rx.UnmarshalAll(re, "Alice", &person) // Pointer to struct, not slice
 		if err == nil {
 			t.Error("UnmarshalAll() expected error for pointer to non-slice, got nil")
 		}
@@ -920,7 +881,7 @@ func TestUnmarshalAll(t *testing.T) {
 	t.Run("error on slice of non-structs", func(t *testing.T) {
 		re := regexp.MustCompile(`(?P<name>\w+)`)
 		var names []string
-		err := UnmarshalAll(re, "Alice", &names) // Slice of strings, not structs
+		err := rx.UnmarshalAll(re, "Alice", &names) // Slice of strings, not structs
 		if err == nil {
 			t.Error("UnmarshalAll() expected error for slice of non-structs, got nil")
 		}
@@ -935,7 +896,7 @@ func ExampleUnmarshalAll() {
 
 	re := regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
 	var people []Person
-	err := UnmarshalAll(re, "Alice is 30 and Bob is 25", &people)
+	err := rx.UnmarshalAll(re, "Alice is 30 and Bob is 25", &people)
 	if err != nil {
 		fmt.Println("Error:", err)
 		return
@@ -977,7 +938,7 @@ func FuzzUnmarshalInt(f *testing.F) {
 		}
 
 		var v intHolder
-		err := Unmarshal(re, raw, &v)
+		err := rx.Unmarshal(re, raw, &v)
 		if err != nil {
 			// Non-int input is allowed to error; just confirm the error message
 			// names the offender clearly.
@@ -1012,7 +973,7 @@ func FuzzUnmarshalUint(f *testing.F) {
 			}
 		}
 		var v uintHolder
-		_ = Unmarshal(re, raw, &v) // allowed to error; just must not panic
+		_ = rx.Unmarshal(re, raw, &v) // allowed to error; just must not panic
 	})
 }
 
@@ -1034,7 +995,7 @@ func FuzzUnmarshalFloat(f *testing.F) {
 			}
 		}
 		var v floatHolder
-		_ = Unmarshal(re, raw, &v) // allowed to error; just must not panic
+		_ = rx.Unmarshal(re, raw, &v) // allowed to error; just must not panic
 	})
 }
 
@@ -1057,7 +1018,7 @@ func FuzzUnmarshalBool(f *testing.F) {
 			}
 		}
 		var v boolHolder
-		_ = Unmarshal(re, raw, &v) // allowed to error; just must not panic
+		_ = rx.Unmarshal(re, raw, &v) // allowed to error; just must not panic
 	})
 }
 


### PR DESCRIPTION
## Summary

Converts the three older test files to `package regextra_test` (external test package). Forces test code through the public API surface — the same way users will call the package — and prevents accidental coupling to unexported internals.

| File | Before | After |
|------|--------|-------|
| `regextra_test.go` | `package regextra` | `package regextra_test` + `rx` import alias |
| `unmarshal_test.go` | `package regextra` | `package regextra_test` + `rx` import alias |
| `bench_test.go` | `package regextra` | `package regextra_test` + `rx` import alias |
| `decoder_test.go` | already `package regextra_test` (#69) | unchanged |

## What's dropped

**`TestParseFieldTag`** — `parseFieldTag` is unexported. Per the design call in `re-h5c`'s acceptance:

> The function is already covered end-to-end by `TestUnmarshalDefault` and `TestUnmarshalLayoutOverride`, which exercise tag parsing via real Unmarshal calls. Granular vs. integration coverage is a wash for a small library, and dropping the direct test makes future tag-parser refactors cheaper.

If a future tag-parser bug ever slips past the integration tests, restore as a small `parsefieldtag_internal_test.go` with `package regextra` (Go allows mixed test packages in the same directory).

## What this proves

| Property | Status |
|---|---|
| All test code uses only the documented public API | ✓ |
| Helper types (status, valueReceiver, etc.) live in the test package | ✓ |
| Benchmarks produce identical numbers (495 ns/op simpleStruct, was 496) | ✓ |
| Race detector clean | ✓ |
| Coverage threshold (85%) holds | ✓ (line coverage of public surface unchanged) |

## Type of change
- [x] Test (no source code changes; behavior identical)

## Test plan
- [x] `go test ./...` — passes
- [x] `go test -race ./...` — passes
- [x] `go vet ./...` — clean
- [x] `gofmt -s -l .` — clean
- [x] Bench smoke: `BenchmarkUnmarshal_simpleStruct` numbers within noise

## Why now (between #69 and Iter[T])

Doing the conversion before the v0.5.0 release tag means users see one consistent test-package convention at v0.5.0, not a mixed shape. `decoder_test.go` was deliberately written external in #69 to set the precedent; this PR brings the older files in line.

Closes #(re-h5c's GH mirror).