### PR TITLE
docs: add Stability + SemVer section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,33 @@ Extensions to Go's regexp package for easier handling of named capture groups.
 go get github.com/jecoms/regextra@latest
 ```
 
+## Stability
+
+`regextra` is pre-v1 and follows SemVer. The exact rules:
+
+**Pre-v1 (current)**
+
+- Patch releases (`v0.x.y`) are fixes only — never breaking.
+- Minor releases (`v0.x.0`) may add features and may include breaking changes. Breaking changes are called out in the [CHANGELOG](./CHANGELOG.md).
+- The path to v1.0 (and what "v1" commits to) is in [ROADMAP.md](./ROADMAP.md).
+
+**Post-v1 (future)**
+
+- Strict SemVer. Breaking changes ship in the next major version, never in a minor or patch.
+
+**What counts as breaking**
+
+- Removing or renaming an exported symbol.
+- Changing the signature of an exported function or method.
+- Changing observable behavior of an existing call (e.g. a previously-returning call now returns an error).
+
+**What does *not* count as breaking**
+
+- Adding a new exported function, type, or method.
+- Adding a new option to the `regex:"..."` struct tag grammar.
+- Accepting additional field types in `Unmarshal` / `UnmarshalAll` / `Decoder`.
+- Changing the wording of error messages. Do not pattern-match on `err.Error()` strings; compare against the exported sentinels (e.g. `regextra.ErrNoMatch` with `errors.Is`) instead.
+
 ## Usage
 
 ```go


### PR DESCRIPTION
## Summary
- Adds a `## Stability` section to the README between Installation and Usage
- Pre-v1 stance: patches are fixes only; minors may add features or break (with CHANGELOG callouts); v1.0 path lives in ROADMAP
- Post-v1 stance: strict SemVer, breaking changes ship in the next major
- Defines what counts as breaking (signature changes, removed symbols, behavior changes) and what doesn't (additions, error-message wording — points users at `errors.Is(err, regextra.ErrNoMatch)` instead of pattern-matching strings)

Closes re-cwi. Part of the v1.0-readiness docs series.

Note: The link to `ROADMAP.md` resolves once #74 lands.

## Test plan
- [ ] Confirm rendered section looks right on GitHub
- [ ] Verify CHANGELOG and ROADMAP cross-links resolve (ROADMAP after #74 merges)