### PR TITLE
chore: add .coderabbit.yaml with chill profile and test-file exclusions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,13 @@
+language: en-US
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  pre_merge_checks:
+    docstrings:
+      mode: warning
+      threshold: 80
+  path_filters:
+    - "!**/*_test.go"
+    - "!examples/**"


### PR DESCRIPTION
## Summary
- Adds `.coderabbit.yaml` at repo root configuring CodeRabbit's review behavior
- `profile: chill` — reduces nit-pick volume during the evaluation window
- `path_filters` excludes `**/*_test.go` and `examples/**` from review (test/bench/fuzz functions don't surface on pkg.go.dev, so docstring requirements there are noise)
- `docstrings` pre-merge check kept at threshold 80 in `warning` mode for files that actually ship

Background: PR #68 (benchmarks) was flagged at 22% docstring coverage; worked around with per-function comments. This is the principled fix.

Closes re-ttb. Last item in the v1.0-readiness docs series (re-217 CoC deferred until there's a community).

## Test plan
- [ ] CodeRabbit picks up the config on this PR (look for the chill-profile review)
- [ ] Confirm test files no longer trigger docstring-coverage warnings on subsequent PRs
- [ ] If CodeRabbit reports config-parse errors, adjust per its docs and amend