### PR TITLE
docs: lock in no-match contract for v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **No-match contract documented.** Added a "No-match behavior" section to the package doc (visible on pkg.go.dev) covering every public function's no-match return. Locks in the intentional asymmetry — `Unmarshal` returns `nil`, `Decoder.One` returns `ErrNoMatch` — as v1 contract, with the rationale spelled out (the `(T, error)` return shape would otherwise make no-match indistinguishable from "decoded a struct of all zero fields"). Per-function docstrings (`Unmarshal`, `UnmarshalAll`, `AllNamedGroups`, `Replace`, `Decoder.One`) cross-reference the canonical section. Behavior unchanged. (re-ne3)
+  - Drive-by fix: `Unmarshal`'s godoc previously claimed it "returns an error if the pattern does not match the target string" — the implementation has always returned `nil` on no match. Docstring now matches behavior.
+
 ## [0.5.0] - 2026-04-26
 
 The architectural perf release. Adds `Decoder[T]` — a typed, regex-bound unmarshaler that compiles its decode plan once and reuses it across calls. **~45% faster on simple-struct decode and ~37% faster on streaming log-line iteration** vs the existing free-function `Unmarshal` / `UnmarshalAll`.

--- a/decoder.go
+++ b/decoder.go
@@ -194,6 +194,11 @@ func lower(s string) string {
 // Returns [ErrNoMatch] if there's no match. Other errors indicate a per-field
 // conversion failure; in that case the returned T contains whatever fields
 // were successfully decoded before the failure.
+//
+// One uses the [ErrNoMatch] sentinel because the (T, error) return shape would
+// otherwise make "no match" indistinguishable from "decoded a struct of all
+// zero fields". Compare with errors.Is. See the package doc's "No-match
+// behavior" section for the full cross-API contract.
 func (d *Decoder[T]) One(target string) (T, error) {
 	matches := d.re.FindStringSubmatch(target)
 	if matches == nil {

--- a/regextra.go
+++ b/regextra.go
@@ -59,6 +59,64 @@ half the time and half the allocations of [Unmarshal] on equivalent input.
 [Decoder.Iter] further skips the slice allocation entirely for streaming
 consumers.
 
+# No-match behavior
+
+Functions in this package handle "the regex did not match the target" differently
+depending on their return shape. The asymmetry is intentional — each call returns
+the no-match form that lets the caller continue without a special-case branch.
+
+	Function                                  No-match return
+	----------------------------------------------------------------------------
+	FindNamed                                 ("", false)
+	FindAllNamed                              []string{} (or nil if the group
+	                                          name is not declared on the regex)
+	NamedGroups, AllNamedGroups               empty map (initialized, not nil)
+	Replace                                   target returned unchanged
+	Validate                                  unrelated — checks declarations,
+	                                          not matches against a target
+	Unmarshal                                 nil error; destination struct left
+	                                          unchanged
+	UnmarshalAll                              nil error; destination slice
+	                                          length set to 0
+	Decoder.One                               zero T, [ErrNoMatch]
+	Decoder.All                               []T{}, nil
+	Decoder.Iter                              iterator yields zero times
+
+The contrast worth understanding is between [Unmarshal] and [Decoder.One]:
+
+  - [Unmarshal] returns nil on no match. The caller passes the destination, so
+    they can inspect their own struct after the call to detect "did anything
+    decode?" — no sentinel needed, and reserving error for genuine failures
+    (bad pointer, type-conversion failure) keeps `if err != nil` meaningful.
+
+  - [Decoder.One] returns [ErrNoMatch]. It returns (T, error), constructing
+    the value itself; a zero-value T paired with nil error would be
+    indistinguishable from "successfully decoded a struct of all zero fields".
+    The sentinel disambiguates. Compare with errors.Is so the check survives
+    wrapping.
+
+Example of the [Decoder.One] no-match check:
+
+	v, err := dec.One(input)
+	if errors.Is(err, regextra.ErrNoMatch) {
+	    // no match — handle as data absence, not failure
+	}
+
+[Decoder.All] and [Decoder.Iter] don't have the ambiguity problem — an empty
+slice and a zero-iteration range are unambiguous — so they follow the same
+"no match is not an error" convention as [UnmarshalAll].
+
+For [FindAllNamed], the nil-vs-empty-slice split is a separate signal:
+
+  - nil — the group name is not declared on the regex (likely a typo; consider
+    [Validate] at startup to catch this).
+  - []string{} — the group is declared but the regex has no matches in the
+    target (data absence — iterate over zero or more).
+
+This distinction is the only place in the no-match table where a single function
+returns two different no-match shapes; everywhere else the no-match form is
+fixed regardless of why the match failed.
+
 # Stability
 
 regextra is pre-v1 and follows SemVer. Patch releases are fixes only. Minor
@@ -162,6 +220,9 @@ func NamedGroups(re *regexp.Regexp, target string) map[string]string {
 // is a slice of all matches for that group. This handles patterns where the same
 // group name appears multiple times.
 //
+// On no match, returns an empty (non-nil) map. See the package doc's
+// "No-match behavior" section for the full cross-API contract.
+//
 // Example:
 //
 //	re := regexp.MustCompile(`(?P<word>\w+) (?P<word>\w+)`)
@@ -196,6 +257,9 @@ func AllNamedGroups(re *regexp.Regexp, target string) map[string][]string {
 // When named groups overlap (nesting), the outermost-named group whose
 // span is encountered first wins; inner groups inside an already-replaced
 // span are not substituted.
+//
+// On no match, returns target unchanged. See the package doc's
+// "No-match behavior" section for the full cross-API contract.
 //
 // Example:
 //

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -55,10 +55,15 @@ func parseTime(value string) (time.Time, error) {
 //   - Supports type conversion for int, int64, float64, and bool
 //   - Unexported fields are ignored
 //
+// On no match, Unmarshal returns nil and leaves *v unchanged — no match is data
+// absence, not a failure. Callers who need to distinguish "matched" from
+// "didn't match" should inspect their struct after the call, or use
+// [Decoder.One] which signals no-match via [ErrNoMatch]. See the package doc's
+// "No-match behavior" section for the full cross-API contract.
+//
 // Returns an error if:
 //   - v is not a pointer to a struct
-//   - The pattern does not match the target string
-//   - Type conversion fails
+//   - Type conversion fails on a matched group
 //
 // Example:
 //
@@ -103,8 +108,10 @@ func Unmarshal(re *regexp.Regexp, target string, v any) error {
 // UnmarshalAll extracts all occurrences of the regex pattern from the target string
 // and unmarshals them into a slice of structs. The slice is cleared before populating.
 //
-// v must be a pointer to a slice of structs. If no matches are found, the slice will
-// be empty (length 0).
+// v must be a pointer to a slice of structs. On no matches, UnmarshalAll returns
+// nil and sets the slice length to 0 — no match is data absence, not a failure.
+// See the package doc's "No-match behavior" section for the full cross-API
+// contract.
 //
 // Example:
 //


### PR DESCRIPTION
## Summary
- Documents the no-match return contract across the public API (FindNamed, FindAllNamed, NamedGroups/AllNamedGroups, Replace, Unmarshal/UnmarshalAll, Decoder.One/All/Iter).
- Adds doc comments to the relevant functions in `regextra.go`, `decoder.go`, `unmarshal.go`.
- Updates `CHANGELOG.md`.

Source: re-ne3

🤖 Generated with [Claude Code](https://claude.com/claude-code)