### PR TITLE
ci: pin golangci-lint and exclude goconst from tests (re-7jg)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,9 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20
       with:
-        version: latest
+        # Pin instead of `latest` so a new golangci-lint release can't turn
+        # CI red without a corresponding bump PR.
+        version: v2.12.1
 
   vet:
     name: Vet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,14 @@ linters:
     - revive        # Fast, configurable linter (golint replacement)
     - unconvert     # Removes unnecessary type conversions
     - unparam       # Reports unused function parameters
+  exclusions:
+    rules:
+      # Test fixtures naturally repeat literals (regex patterns, sample
+      # inputs, expected values). Hoisting them into constants hurts
+      # readability — each test should be self-contained.
+      - path: _test\.go
+        linters:
+          - goconst
 
 run:
   timeout: 5m


### PR DESCRIPTION
## Summary

- Pin `golangci-lint-action` to **v2.12.1** instead of `latest` so a future release can't silently break CI.
- Add a goconst exclusion for `_test.go` files — test fixtures naturally repeat literals (regex patterns, sample inputs, expected values) and hoisting them into shared constants hurts readability.

A recent `golangci-lint` release surfaced goconst warnings on existing test fixtures, turning Lint red on every PR and main push, which forced refinery to bypass auto-merge with `--admin`.

Closes re-7jg.

## Test plan

- [ ] Lint job is green on this PR
- [ ] Confirm refinery can auto-merge once Lint is reliably green

🤖 Generated with [Claude Code](https://claude.com/claude-code)