### PR TITLE
chore(release): v1.0.0 (re-0na)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-05-05
+
+The API-stability stamp. Every public surface in `regextra.go`, `unmarshal.go`, and `decoder.go` was audited by the v1-readiness review (`docs/v1-readiness.md`) and carries a documented `Keep` verdict. The three "change before v1" blockers from that review (`AllNamedGroups` naming, tag-grammar reservation policy, no-match contract) all resolved as documentation lock-ins — every behavior in the v0.5.0 release ships unchanged into v1.0.0.
+
+**The promise.** Post-v1, breaking changes ship in the next major version, never in a minor or patch. Adopters can pin `v1` and follow minor/patch updates without re-reading release notes for migration steps. See [README §Stability](./README.md#stability) for the precise definition of "breaking" and the non-breaking change set (additions, new tag-option keys, additional field types, error-message wording).
+
+**No code changes** vs `v0.5.0`. The release exists to mark the stability commitment and to land the documentation that locks in pre-v1 contracts as v1 contracts.
+
 ### Documentation
 
 - **`AllNamedGroups` naming clarified for v1.** Rewrote the `AllNamedGroups` docstring and the README's reference entry to lead with the duplicate-group-name use case and to state explicitly that the function operates on a single match — the leading "All" refers to all named groups in one match, not to all matches in the target. `FindAllNamed`'s cross-reference now calls out the asymmetry rather than implying symmetry. The package doc's "API at a glance" entry was also corrected (it previously read "every named group across all matches", which inverts the actual behavior). Resolution of the `re-zwj` v1 blocker — option 3 (lock in current name, fix the docs) chosen over rename or new helper, on the grounds that the name is technically correct, the roadmap does not commit to a future `[]map[string]string` shape, and rename pre-v1 has real adopter cost. Behavior unchanged. (re-zwj)

--- a/README.md
+++ b/README.md
@@ -17,17 +17,13 @@ go get github.com/jecoms/regextra@latest
 
 ## Stability
 
-`regextra` is pre-v1 and follows SemVer. The exact rules:
+`regextra` is at v1 and follows strict SemVer:
 
-**Pre-v1 (current)**
+- Breaking changes ship in the next major version (`v2.0.0`), never in a minor or patch.
+- Minor releases (`v1.x.0`) add features.
+- Patch releases (`v1.x.y`) are fixes only.
 
-- Patch releases (`v0.x.y`) are fixes only — never breaking.
-- Minor releases (`v0.x.0`) may add features and may include breaking changes. Breaking changes are called out in the [CHANGELOG](./CHANGELOG.md).
-- The path to v1.0 (and what "v1" commits to) is in [ROADMAP.md](./ROADMAP.md).
-
-**Post-v1 (future)**
-
-- Strict SemVer. Breaking changes ship in the next major version, never in a minor or patch.
+The audit that pinned every public surface as v1 contract lives in [docs/v1-readiness.md](./docs/v1-readiness.md). The forward look is in [ROADMAP.md](./ROADMAP.md).
 
 **What counts as breaking**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,9 @@ A high-level view of where `regextra` is heading. The [issue tracker](https://gi
 
 ## Current release
 
-**v0.5.0** — typed cached decode (`Compile[T]` / `Decoder[T]`) with streaming via `Decoder.Iter` (range-over-func). Roughly half the time and half the allocations of `Unmarshal` for repeated decode of the same shape; `Iter` skips slice allocation entirely for streaming consumers.
+**v1.0.0** — the API-stability stamp. Every public surface audited by the [v1-readiness review](./docs/v1-readiness.md) and pinned as v1 contract. No behavior changes vs v0.5.0; the release exists to mark the stability commitment.
+
+What that means for adopters: post-v1, breaking changes ship only in the next major version (`v2.0.0`). Pin `v1` and follow minor/patch updates without re-reading release notes for migration steps. See the [README's Stability section](./README.md#stability) for the precise definition of "breaking".
 
 See the [CHANGELOG](./CHANGELOG.md) for the full history.
 
@@ -15,16 +17,14 @@ Theme: **make the unmarshal contract more expressive without expanding the API s
 - Tag-derived required-group validation — let callers mark a struct field as required directly on its `regex:"name,required"` tag, replacing the separate `Validate` call for the common case.
 - Possibly: `Encoder[T]` for typed round-trip via template syntax — symmetric counterpart to `Decoder[T]` for callers building strings from typed structs.
 
-Specific issues are tracked in the [issue tracker](https://github.com/Jecoms/regextra/issues).
+Additive nice-to-haves identified by the v1-readiness review (post-v1, non-breaking):
 
-## Working toward v1.0
+- `ReplaceFirst` for one-match substitution (symmetric to `Replace`).
+- Typed `*ValidationError` so callers can `errors.As` instead of parsing message text.
+- Sentinel errors for `Compile` / `MustCompile` failure categories.
+- `Decoder.Regexp() *regexp.Regexp` accessor for callers that want their own match-finding while reusing the typed decode plan.
 
-v1.0 is the API-stability promise: post-v1, breaking changes ship in the next major version. The gating work:
-
-- **API stability review** — complete. The full audit lives in [docs/v1-readiness.md](./docs/v1-readiness.md); every public symbol carries a verdict. The three "change before v1" blockers from that review (`AllNamedGroups` naming clarity, tag-grammar reservation policy, no-match contract) have all been resolved via documentation lock-ins — see the [CHANGELOG](./CHANGELOG.md).
-- **Documentation polish** — pkg.go.dev landing has been expanded and the README's [Stability](./README.md#stability) section spells out what "breaking" means. Remaining nice-to-haves: a trimmed README and a dedicated examples folder. Doc polish does not block the v1 stamp.
-
-What this means for adopters: pre-v1 the package follows SemVer with breaking changes signaled by minor bumps. After v1.0, breaking changes signal the next major version.
+These ship when concrete adopter demand surfaces. Specific issues are tracked in the [issue tracker](https://github.com/Jecoms/regextra/issues).
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- Cuts the v1.0.0 release: CHANGELOG entry, README polish, ROADMAP updates marking v1 complete.

Closes re-0na.

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./...

🤖 Generated with [Claude Code](https://claude.com/claude-code)