### PR TITLE
docs: refresh ROADMAP to reflect closed v1 gate (re-sxy)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,10 +21,10 @@ Specific issues are tracked in the [issue tracker](https://github.com/Jecoms/reg
 
 v1.0 is the API-stability promise: post-v1, breaking changes ship in the next major version. The gating work:
 
-- **API stability review** — full audit of the public surface (function signatures, exported types, tag grammar, error sentinels) for anything we'd regret committing to. This is the single hard gate on v1.0.
-- **Documentation polish** — package doc on pkg.go.dev as the canonical API reference, README slimmed to quick-start + showcase, examples folder.
+- **API stability review** — complete. The full audit lives in [docs/v1-readiness.md](./docs/v1-readiness.md); every public symbol carries a verdict. The three "change before v1" blockers from that review (`AllNamedGroups` naming clarity, tag-grammar reservation policy, no-match contract) have all been resolved via documentation lock-ins — see the [CHANGELOG](./CHANGELOG.md).
+- **Documentation polish** — pkg.go.dev landing has been expanded and the README's [Stability](./README.md#stability) section spells out what "breaking" means. Remaining nice-to-haves: a trimmed README and a dedicated examples folder. Doc polish does not block the v1 stamp.
 
-What this means for adopters: pre-v1 the package follows SemVer with breaking changes signaled by minor bumps. After v1.0, breaking changes signal the next major version. The README's Stability section will spell out the precise definition of "breaking" once it lands as part of the v1.0-readiness docs.
+What this means for adopters: pre-v1 the package follows SemVer with breaking changes signaled by minor bumps. After v1.0, breaking changes signal the next major version.
 
 ## Backlog
 


### PR DESCRIPTION
The 'Working toward v1.0' section was stale:

- API stability review was framed as the single hard v1 gate, but docs/v1-readiness.md (#82) plus the three blocker resolutions (#83 no-match, #85 tag grammar, #89 AllNamedGroups) closed it out. Updated bullet to point to the v1-readiness doc and CHANGELOG and to mark the audit complete.
- Documentation polish was framed as future work, but the pkg.go.dev landing (#76) and README Stability section (#75) have already shipped. Reframed to call out what landed vs the remaining nice-to-haves (README trim, examples folder), with a note that doc polish is not a v1 blocker.
- Dropped the trailing forward reference to the README Stability section 'once it lands' — it landed in #75.

<!--
Use a Conventional Commits subject for the PR title (e.g. `feat: …`, `fix: …`,
`chore: …`, `ci: …`, `docs: …`, `refactor: …`, `test: …`, `perf: …`). Squash-merge
turns the PR title into the commit subject — keep it short and accurate.
-->

## Summary
<!-- What changed and why. One short paragraph or 2–3 bullets. -->

## Type of change
- [ ] Feature (new public API or behavior)
- [ ] Fix (bug correction, no API change)
- [ ] Chore / CI / docs / refactor (no behavior change)
- [ ] Breaking change (semver minor pre-1.0, major post-1.0)

## CHANGELOG
<!-- For features and fixes, paste the entry you added under `## [Unreleased]`. -->

## Test plan
- [ ] `go test ./...` passes locally
- [ ] `go test -race ./...` passes if touching shared state
- [ ] `golangci-lint run` is clean
- [ ] New behavior covered by tests / examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated v1.0 roadmap to reflect completed API-stability review status and clarified documentation improvements, including package documentation landing page expansion and README updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->