### PR TITLE
docs: fix stale pre-v1 stability claim in package doc

### DIFF
--- a/regextra.go
+++ b/regextra.go
@@ -158,11 +158,11 @@ grammar) or a recognized flag token (claiming a previously-ignored slot).
 
 # Stability
 
-regextra is pre-v1 and follows SemVer. Patch releases are fixes only. Minor
-releases may add features and may include breaking changes (called out in the
-CHANGELOG). Post-v1, breaking changes will ship in the next major version.
-See ROADMAP.md and the README's Stability section for the precise contract,
-including what does and does not count as breaking.
+regextra is at v1 and follows strict SemVer. Patch releases are fixes only.
+Minor releases add features without breaking changes. Breaking changes ship
+in the next major version, never in a minor or patch. See ROADMAP.md and the
+README's Stability section for the precise contract, including what does and
+does not count as breaking.
 
 # More
 


### PR DESCRIPTION
Fixes #112.

The package doc's Stability section (visible on pkg.go.dev) still said "regextra is pre-v1 ... Minor releases may add features and may include breaking changes," contradicting README.md and ROADMAP.md, which document the v1.0.0 strict-SemVer commitment. The section now states the v1 contract: patch = fixes only, minor = additive only, breaking changes only in the next major.

Docs-only; no behavior change. CHANGELOG entry deferred to release prep to keep the parallel fix PRs conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package documentation to reflect v1 stability semantics, clarifying how patch, minor, and breaking changes are handled under the updated versioning contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->