### PR TITLE
fix(unmarshal): error on numeric overflow instead of silently truncating

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -400,25 +400,28 @@ func setFieldValue(field reflect.Value, value string, opts map[string]string) er
 		return nil
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		intVal, err := strconv.ParseInt(value, 10, 64)
+		// Parse at the field's actual bit width so out-of-range values error
+		// instead of silently truncating on SetInt (same approach as
+		// encoding/json).
+		intVal, err := strconv.ParseInt(value, 10, field.Type().Bits())
 		if err != nil {
-			return fmt.Errorf("cannot convert %q to int: %w", value, err)
+			return fmt.Errorf("cannot convert %q to %s: %w", value, field.Type(), err)
 		}
 		field.SetInt(intVal)
 		return nil
 
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		uintVal, err := strconv.ParseUint(value, 10, 64)
+		uintVal, err := strconv.ParseUint(value, 10, field.Type().Bits())
 		if err != nil {
-			return fmt.Errorf("cannot convert %q to uint: %w", value, err)
+			return fmt.Errorf("cannot convert %q to %s: %w", value, field.Type(), err)
 		}
 		field.SetUint(uintVal)
 		return nil
 
 	case reflect.Float32, reflect.Float64:
-		floatVal, err := strconv.ParseFloat(value, 64)
+		floatVal, err := strconv.ParseFloat(value, field.Type().Bits())
 		if err != nil {
-			return fmt.Errorf("cannot convert %q to float: %w", value, err)
+			return fmt.Errorf("cannot convert %q to %s: %w", value, field.Type(), err)
 		}
 		field.SetFloat(floatVal)
 		return nil

--- a/unmarshal_overflow_test.go
+++ b/unmarshal_overflow_test.go
@@ -1,0 +1,154 @@
+package regextra
+
+import (
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Regression tests for https://github.com/Jecoms/regextra/issues/103:
+// values out of range for narrow numeric fields must error instead of
+// silently truncating (e.g. "300" into int8 previously yielded 44, nil).
+
+func TestUnmarshal_intOverflow(t *testing.T) {
+	re := regexp.MustCompile(`(?P<n>-?\d+)`)
+
+	t.Run("int8 overflow errors", func(t *testing.T) {
+		var dst struct {
+			N int8 `regex:"n"`
+		}
+		err := Unmarshal(re, "300", &dst)
+		if err == nil {
+			t.Fatalf("expected overflow error, got nil (N = %d)", dst.N)
+		}
+		if !strings.Contains(err.Error(), "cannot convert") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("int8 underflow errors", func(t *testing.T) {
+		var dst struct {
+			N int8 `regex:"n"`
+		}
+		if err := Unmarshal(re, "-129", &dst); err == nil {
+			t.Fatalf("expected underflow error, got nil (N = %d)", dst.N)
+		}
+	})
+
+	t.Run("int8 bounds fit", func(t *testing.T) {
+		var dst struct {
+			Lo int8 `regex:"n"`
+		}
+		if err := Unmarshal(re, "127", &dst); err != nil {
+			t.Fatalf("127 should fit in int8: %v", err)
+		}
+		if dst.Lo != math.MaxInt8 {
+			t.Errorf("Lo = %d, want 127", dst.Lo)
+		}
+		if err := Unmarshal(re, "-128", &dst); err != nil {
+			t.Fatalf("-128 should fit in int8: %v", err)
+		}
+		if dst.Lo != math.MinInt8 {
+			t.Errorf("Lo = %d, want -128", dst.Lo)
+		}
+	})
+
+	t.Run("int16 and int32 overflow errors", func(t *testing.T) {
+		var dst16 struct {
+			N int16 `regex:"n"`
+		}
+		if err := Unmarshal(re, "40000", &dst16); err == nil {
+			t.Errorf("expected int16 overflow error, got nil (N = %d)", dst16.N)
+		}
+		var dst32 struct {
+			N int32 `regex:"n"`
+		}
+		if err := Unmarshal(re, strconv.FormatInt(math.MaxInt32+1, 10), &dst32); err == nil {
+			t.Errorf("expected int32 overflow error, got nil (N = %d)", dst32.N)
+		}
+	})
+}
+
+func TestUnmarshal_uintOverflow(t *testing.T) {
+	re := regexp.MustCompile(`(?P<n>\d+)`)
+
+	t.Run("uint8 overflow errors", func(t *testing.T) {
+		var dst struct {
+			N uint8 `regex:"n"`
+		}
+		if err := Unmarshal(re, "256", &dst); err == nil {
+			t.Fatalf("expected overflow error, got nil (N = %d)", dst.N)
+		}
+	})
+
+	t.Run("uint8 max fits", func(t *testing.T) {
+		var dst struct {
+			N uint8 `regex:"n"`
+		}
+		if err := Unmarshal(re, "255", &dst); err != nil {
+			t.Fatalf("255 should fit in uint8: %v", err)
+		}
+		if dst.N != math.MaxUint8 {
+			t.Errorf("N = %d, want 255", dst.N)
+		}
+	})
+}
+
+func TestUnmarshal_floatOverflow(t *testing.T) {
+	re := regexp.MustCompile(`(?P<n>[\d.e+]+)`)
+
+	t.Run("float32 overflow errors", func(t *testing.T) {
+		var dst struct {
+			N float32 `regex:"n"`
+		}
+		if err := Unmarshal(re, "1e308", &dst); err == nil {
+			t.Fatalf("expected overflow error, got nil (N = %g)", dst.N)
+		}
+	})
+
+	t.Run("float32 in range fits", func(t *testing.T) {
+		var dst struct {
+			N float32 `regex:"n"`
+		}
+		if err := Unmarshal(re, "3.5", &dst); err != nil {
+			t.Fatalf("3.5 should fit in float32: %v", err)
+		}
+		if dst.N != 3.5 {
+			t.Errorf("N = %g, want 3.5", dst.N)
+		}
+	})
+
+	t.Run("float64 still accepts large values", func(t *testing.T) {
+		var dst struct {
+			N float64 `regex:"n"`
+		}
+		if err := Unmarshal(re, "1e308", &dst); err != nil {
+			t.Fatalf("1e308 fits in float64: %v", err)
+		}
+	})
+}
+
+// The Decoder shares setFieldValue, so overflow must error there too — both
+// at decode time and when validating a default= at Compile time.
+func TestDecoder_overflow(t *testing.T) {
+	t.Run("One errors on overflow", func(t *testing.T) {
+		type rec struct {
+			N int8 `regex:"n"`
+		}
+		dec := MustCompile[rec](`(?P<n>\d+)`)
+		if _, err := dec.One("300"); err == nil {
+			t.Fatal("expected overflow error, got nil")
+		}
+	})
+
+	t.Run("Compile rejects out-of-range default", func(t *testing.T) {
+		type rec struct {
+			N int8 `regex:"n,default=300"`
+		}
+		if _, err := Compile[rec](`(?P<n>\d+)`); err == nil {
+			t.Fatal("expected Compile error for out-of-range default, got nil")
+		}
+	})
+}


### PR DESCRIPTION
Fixes #103.

setFieldValue parsed all numeric values at 64-bit width regardless of the destination field's type, then SetInt/SetUint/SetFloat silently truncated: `"300"` into an `int8` field yielded **44 with a nil error**, and `"1e308"` into `float32` yielded +Inf. Now strconv parses at `field.Type().Bits()` (the encoding/json approach), so out-of-range values return a conversion error.

Also reached for free: `Compile` now rejects `default=` values that don't fit the field's width, since the eager default probe runs through the same conversion path.

Conversion error messages now name the concrete field type (`cannot convert "300" to int8`) instead of the kind family — error wording is explicitly non-contractual per the README.

**SemVer note:** strictly this turns a previously-nil-returning call into an erroring one for overflow inputs, which the README's breaking-change list mentions — but the prior behavior was silent data corruption, so this is classified as a bug fix. Flagging for your judgment; deserves a prominent CHANGELOG entry either way.

Tests: new `unmarshal_overflow_test.go` covering int8/int16/int32 over/underflow, uint8 overflow, float32 overflow, exact-boundary fits, and the Decoder/Compile paths. CHANGELOG entry deferred to release prep to keep the parallel fix PRs conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)