### PR TITLE
fix: enforce outermost-wins deterministically in Replace

### DIFF
--- a/regextra.go
+++ b/regextra.go
@@ -359,7 +359,15 @@ func Replace(re *regexp.Regexp, target string, replacements map[string]string) s
 			}
 			spans = append(spans, span{start: s, end: e, repl: repl})
 		}
-		sort.Slice(spans, func(i, j int) bool { return spans[i].start < spans[j].start })
+		// Order by start; when spans start at the same offset (nested groups),
+		// the longer span sorts first so the documented "outermost wins" rule
+		// is enforced rather than left to sort-internals luck.
+		sort.SliceStable(spans, func(i, j int) bool {
+			if spans[i].start != spans[j].start {
+				return spans[i].start < spans[j].start
+			}
+			return spans[i].end > spans[j].end
+		})
 		for _, sp := range spans {
 			if sp.start < cursor {
 				continue // already covered (overlap with an earlier substitution)

--- a/replace_order_test.go
+++ b/replace_order_test.go
@@ -1,0 +1,73 @@
+package regextra
+
+import (
+	"regexp"
+	"testing"
+)
+
+// Regression tests for https://github.com/Jecoms/regextra/issues/107:
+// when nested named groups start at the same offset, the documented
+// "outermost wins" rule must hold deterministically, not depend on
+// sort internals.
+
+func TestReplace_nestedSameStartOutermostWins(t *testing.T) {
+	re := regexp.MustCompile(`(?P<outer>(?P<inner>x)y)`)
+
+	t.Run("both groups in map: outer wins", func(t *testing.T) {
+		got := Replace(re, "axyb", map[string]string{
+			"outer": "OUTER",
+			"inner": "INNER",
+		})
+		if got != "aOUTERb" {
+			t.Errorf("got %q, want %q", got, "aOUTERb")
+		}
+	})
+
+	t.Run("only inner in map: inner replaced", func(t *testing.T) {
+		got := Replace(re, "axyb", map[string]string{"inner": "I"})
+		if got != "aIyb" {
+			t.Errorf("got %q, want %q", got, "aIyb")
+		}
+	})
+
+	t.Run("only outer in map: outer replaced", func(t *testing.T) {
+		got := Replace(re, "axyb", map[string]string{"outer": "O"})
+		if got != "aOb" {
+			t.Errorf("got %q, want %q", got, "aOb")
+		}
+	})
+
+	// Three levels of same-start nesting; outermost must still win even when
+	// the slice has more than two same-start spans (where an unstable sort's
+	// behavior would be least predictable).
+	t.Run("three nested levels", func(t *testing.T) {
+		re3 := regexp.MustCompile(`(?P<a>(?P<b>(?P<c>x)y)z)`)
+		got := Replace(re3, "-xyz-", map[string]string{
+			"a": "A",
+			"b": "B",
+			"c": "C",
+		})
+		if got != "-A-" {
+			t.Errorf("got %q, want %q", got, "-A-")
+		}
+	})
+}
+
+func TestReplace_nestedNotSameStart(t *testing.T) {
+	// The outer group starts before the inner; the earlier span wins and the
+	// inner group inside the already-replaced span is skipped.
+	re := regexp.MustCompile(`(?P<outer>a(?P<inner>x)b)`)
+	got := Replace(re, "-axb-", map[string]string{
+		"outer": "O",
+		"inner": "I",
+	})
+	if got != "-O-" {
+		t.Errorf("got %q, want %q", got, "-O-")
+	}
+
+	// Inner only: replaced inside untouched outer text.
+	got = Replace(re, "-axb-", map[string]string{"inner": "I"})
+	if got != "-aIb-" {
+		t.Errorf("got %q, want %q", got, "-aIb-")
+	}
+}


### PR DESCRIPTION
Fixes #107.

`Replace` sorted replacement spans with the unstable `sort.Slice`, ordered only by start offset. For nested groups starting at the same offset — `(?P<outer>(?P<inner>x)y)` with both names in the replacements map — the documented "outermost wins" rule held only by sort-internals luck. Now `sort.SliceStable` with an explicit tie-break (same start → longer span first) enforces the invariant.

Tests: new `replace_order_test.go` covering same-start nesting at two and three levels (where unstable-sort behavior is least predictable), inner-only and outer-only replacement, and non-same-start nesting. These also close part of the untested-documented-behaviors gap tracked in #114.

CHANGELOG entry deferred to release prep to keep the parallel fix PRs conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)