### PR TITLE
fix: handle duplicate group names in map and decoder paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Duplicate group names no longer lose the participating value.** Go's `regexp` allows the same `(?P<name>...)` to appear more than once in a pattern (e.g. across alternation branches), where only one occurrence participates in a given match. Every name-based reader now resolves the occurrence that actually participated instead of trusting `re.SubexpIndex`'s first occurrence or letting a later empty/non-participating occurrence clobber a real value. Affects `NamedGroups`, `Unmarshal`, `UnmarshalAll`, `Decoder.One`/`Decoder.All`/`Decoder.Iter`, `FindNamed`, and `FindAllNamed`. For example, with `(?:x(?P<word>a)|y(?P<word>b))`, `FindNamed(re, "yb", "word")` now returns `("b", true)` (was `("", true)`) and `FindAllNamed(re, "xa yb", "word")` returns `["a", "b"]` (was `["a", ""]`). ([#127](https://github.com/Jecoms/regextra/pull/127), fixes [#105](https://github.com/Jecoms/regextra/issues/105))
+- **`Unmarshal`/`UnmarshalAll` no longer error on a non-participating optional group with a typed field.** A declared optional group that does not participate in the match (e.g. `(?P<num>\d+)?` against input with no digits) is now left at the field's zero value, matching `Decoder.One`, instead of feeding `""` into the numeric/bool/time conversion and returning `cannot convert "" to …`. Fields with a `default=` still substitute the default as before, and `NamedGroups` still reports a non-participating group as `""`. ([#127](https://github.com/Jecoms/regextra/pull/127))
+
+### Performance
+
+- Switching the `Decoder` to the index-returning match functions (`FindStringSubmatchIndex` / `FindAllStringSubmatchIndex`) — required to tell a participating-empty group from a non-participating one — also drops a per-match allocation: `Decoder.One` on a simple struct goes from 3 allocs to 2 (−40% B/op) and `Decoder.Iter` over 100 log lines from 309 allocs to 209 (−32%). ([#127](https://github.com/Jecoms/regextra/pull/127))
+
 ## [1.0.0] - 2026-05-05
 
 The API-stability stamp. Every public surface in `regextra.go`, `unmarshal.go`, and `decoder.go` was audited by the v1-readiness review (`docs/v1-readiness.md`) and carries a documented `Keep` verdict. The three "change before v1" blockers from that review (`AllNamedGroups` naming, tag-grammar reservation policy, no-match contract) all resolved as documentation lock-ins — every behavior in the v0.5.0 release ships unchanged into v1.0.0.

--- a/decoder.go
+++ b/decoder.go
@@ -45,9 +45,14 @@ type Decoder[T any] struct {
 type fieldDecoder struct {
 	// fieldIndex is the index into T's struct fields (StructField.Index[0]).
 	fieldIndex int
-	// groupIndex is the regex SubexpIndex for the named group; -1 means
-	// "no group declared, use default if present, otherwise skip."
-	groupIndex int
+	// groupIndexes holds the submatch index of every occurrence of the
+	// field's group name, in declaration order. Go's regexp allows the same
+	// group name to appear more than once in a pattern (e.g. across
+	// alternation branches), and only one occurrence participates in a given
+	// match — decode scans them all rather than trusting SubexpIndex's first
+	// occurrence. Empty means "no group declared, use default if present,
+	// otherwise skip."
+	groupIndexes []int
 	// opts is the parsed tag options map (e.g. {"default": "guest", "layout": "..."}).
 	// Nil if the field has no options.
 	opts map[string]string
@@ -112,10 +117,10 @@ func compileDecoder[T any](pattern string, re *regexp.Regexp) (*Decoder[T], erro
 		}
 
 		_, hasDefault := opts["default"]
-		groupIdx := -1
+		var groupIdxs []int
 		if groupName != "" {
-			groupIdx = re.SubexpIndex(groupName)
-			if groupIdx == -1 && !hasDefault {
+			groupIdxs = subexpIndexes(re, groupName)
+			if len(groupIdxs) == 0 && !hasDefault {
 				// Missing group with no default IS a typo — fail at compile.
 				// With a default, missing group is intentional (the default
 				// always fires).
@@ -146,18 +151,32 @@ func compileDecoder[T any](pattern string, re *regexp.Regexp) (*Decoder[T], erro
 
 		// Skip fields that have neither a group mapping nor a default —
 		// they'd be no-ops at decode time.
-		if groupIdx == -1 && !hasDefault {
+		if len(groupIdxs) == 0 && !hasDefault {
 			continue
 		}
 
 		d.fields = append(d.fields, fieldDecoder{
-			fieldIndex: i,
-			groupIndex: groupIdx,
-			opts:       opts,
+			fieldIndex:   i,
+			groupIndexes: groupIdxs,
+			opts:         opts,
 		})
 	}
 
 	return d, nil
+}
+
+// subexpIndexes returns the submatch index of every occurrence of the named
+// group on re, in declaration order. Unlike re.SubexpIndex, which reports
+// only the first occurrence, this captures duplicates so decode can find the
+// occurrence that actually participated in a match.
+func subexpIndexes(re *regexp.Regexp, name string) []int {
+	var idxs []int
+	for i, n := range re.SubexpNames() {
+		if i != 0 && n == name {
+			idxs = append(idxs, i)
+		}
+	}
+	return idxs
 }
 
 // matchGroupName returns the declared group name on re that matches fieldName
@@ -200,13 +219,13 @@ func lower(s string) string {
 // zero fields". Compare with errors.Is. See the package doc's "No-match
 // behavior" section for the full cross-API contract.
 func (d *Decoder[T]) One(target string) (T, error) {
-	matches := d.re.FindStringSubmatch(target)
+	matches := d.re.FindStringSubmatchIndex(target)
 	if matches == nil {
 		return d.zero, ErrNoMatch
 	}
 	var v T
 	rv := reflect.ValueOf(&v).Elem()
-	if err := d.decode(rv, matches); err != nil {
+	if err := d.decode(rv, target, matches); err != nil {
 		return v, err
 	}
 	return v, nil
@@ -217,14 +236,14 @@ func (d *Decoder[T]) One(target string) (T, error) {
 // error indicates a per-field conversion failure on one of the matches; the
 // slice up to that point may contain partially-decoded entries.
 func (d *Decoder[T]) All(target string) ([]T, error) {
-	allMatches := d.re.FindAllStringSubmatch(target, -1)
+	allMatches := d.re.FindAllStringSubmatchIndex(target, -1)
 	if len(allMatches) == 0 {
 		return []T{}, nil
 	}
 	out := make([]T, len(allMatches))
 	for i, matches := range allMatches {
 		rv := reflect.ValueOf(&out[i]).Elem()
-		if err := d.decode(rv, matches); err != nil {
+		if err := d.decode(rv, target, matches); err != nil {
 			return out[:i+1], fmt.Errorf("regextra.Decoder.All: match %d: %w", i, err)
 		}
 	}
@@ -255,11 +274,11 @@ func (d *Decoder[T]) All(target string) ([]T, error) {
 // For a single match with a sentinel ErrNoMatch, prefer [Decoder.One].
 func (d *Decoder[T]) Iter(target string) iter.Seq2[T, error] {
 	return func(yield func(T, error) bool) {
-		allMatches := d.re.FindAllStringSubmatch(target, -1)
+		allMatches := d.re.FindAllStringSubmatchIndex(target, -1)
 		for _, matches := range allMatches {
 			var v T
 			rv := reflect.ValueOf(&v).Elem()
-			err := d.decode(rv, matches)
+			err := d.decode(rv, target, matches)
 			if !yield(v, err) {
 				return
 			}
@@ -274,17 +293,33 @@ func (d *Decoder[T]) Pattern() string {
 }
 
 // decode walks the precomputed field plan against a single match's group
-// values and writes them into rv (the addressable reflect.Value of a T).
-func (d *Decoder[T]) decode(rv reflect.Value, matches []string) error {
+// indices and writes the values into rv (the addressable reflect.Value of a
+// T). matches is a FindStringSubmatchIndex-style index slice (or one element
+// of FindAllStringSubmatchIndex); target is the string those indices slice
+// into.
+func (d *Decoder[T]) decode(rv reflect.Value, target string, matches []int) error {
 	for _, fd := range d.fields {
+		// Pick the value the same way the Unmarshal path does (see
+		// namedGroupValues): the last occurrence that participated in the
+		// match wins, even if it matched an empty span. A non-participating
+		// occurrence (negative start index) never overwrites a participating
+		// one. Index pairs are what make this possible — FindStringSubmatch's
+		// strings can't tell a participating-empty group from a
+		// non-participating one. The index slice always holds 2*(NumSubexp+1)
+		// entries, so 2*gi+1 is always in range.
 		var value string
 		var found bool
-		if fd.groupIndex >= 0 && fd.groupIndex < len(matches) {
-			value = matches[fd.groupIndex]
-			// regexp returns "" for non-participating groups; treat as not-found
-			// so the default-fallback logic below kicks in.
-			found = value != "" || fd.groupIndex == 0
+		for _, gi := range fd.groupIndexes {
+			start := matches[2*gi]
+			if start < 0 {
+				continue
+			}
+			value = target[start:matches[2*gi+1]]
+			found = true
 		}
+		// default= substitutes when no occurrence participated OR the winning
+		// value is empty — the same rule populateStruct applies on the
+		// Unmarshal path.
 		if !found || value == "" {
 			if def, ok := fd.opts["default"]; ok {
 				value = def

--- a/duplicate_groups_test.go
+++ b/duplicate_groups_test.go
@@ -1,0 +1,229 @@
+package regextra
+
+import (
+	"regexp"
+	"testing"
+)
+
+// Regression tests for https://github.com/Jecoms/regextra/issues/105:
+// patterns that reuse a group name (legal in Go's regexp, e.g. across
+// alternation branches) were mishandled in both decode paths — the map
+// builders let a non-participating later occurrence clobber the real value
+// with "", and the Decoder read only SubexpIndex's first occurrence.
+
+func TestNamedGroups_duplicateNames(t *testing.T) {
+	re := regexp.MustCompile(`(?:x(?P<word>a)|y(?P<word>b))`)
+
+	t.Run("first alternation branch participates", func(t *testing.T) {
+		got := NamedGroups(re, "xa")
+		if got["word"] != "a" {
+			t.Errorf(`got word=%q, want "a" (non-participating duplicate must not clobber)`, got["word"])
+		}
+	})
+
+	t.Run("second alternation branch participates", func(t *testing.T) {
+		got := NamedGroups(re, "yb")
+		if got["word"] != "b" {
+			t.Errorf(`got word=%q, want "b"`, got["word"])
+		}
+	})
+
+	t.Run("sequential duplicates keep last-wins", func(t *testing.T) {
+		seq := regexp.MustCompile(`(?P<word>\w+) (?P<word>\w+)`)
+		got := NamedGroups(seq, "hello world")
+		if got["word"] != "world" {
+			t.Errorf(`got word=%q, want "world" (last participating occurrence wins)`, got["word"])
+		}
+	})
+
+	t.Run("AllNamedGroups still preserves every occurrence", func(t *testing.T) {
+		got := AllNamedGroups(re, "xa")
+		want := []string{"a", ""}
+		if len(got["word"]) != 2 || got["word"][0] != want[0] || got["word"][1] != want[1] {
+			t.Errorf("got word=%q, want %q", got["word"], want)
+		}
+	})
+}
+
+func TestUnmarshal_duplicateNames(t *testing.T) {
+	re := regexp.MustCompile(`(?:x(?P<word>a)|y(?P<word>b))`)
+	type rec struct {
+		Word string `regex:"word"`
+	}
+
+	for input, want := range map[string]string{"xa": "a", "yb": "b"} {
+		var r rec
+		if err := Unmarshal(re, input, &r); err != nil {
+			t.Fatalf("Unmarshal(%q): %v", input, err)
+		}
+		if r.Word != want {
+			t.Errorf("Unmarshal(%q): Word = %q, want %q", input, r.Word, want)
+		}
+	}
+}
+
+func TestUnmarshalAll_duplicateNames(t *testing.T) {
+	re := regexp.MustCompile(`(?:x(?P<word>a)|y(?P<word>b))`)
+	type rec struct {
+		Word string `regex:"word"`
+	}
+
+	var recs []rec
+	if err := UnmarshalAll(re, "xa yb xa", &recs); err != nil {
+		t.Fatalf("UnmarshalAll: %v", err)
+	}
+	want := []string{"a", "b", "a"}
+	if len(recs) != len(want) {
+		t.Fatalf("got %d matches, want %d", len(recs), len(want))
+	}
+	for i, w := range want {
+		if recs[i].Word != w {
+			t.Errorf("match %d: Word = %q, want %q", i, recs[i].Word, w)
+		}
+	}
+}
+
+func TestDecoder_duplicateNames(t *testing.T) {
+	type rec struct {
+		Word string `regex:"word"`
+	}
+	dec := MustCompile[rec](`(?:x(?P<word>a)|y(?P<word>b))`)
+
+	t.Run("One finds the participating occurrence in either branch", func(t *testing.T) {
+		for input, want := range map[string]string{"xa": "a", "yb": "b"} {
+			got, err := dec.One(input)
+			if err != nil {
+				t.Fatalf("One(%q): %v", input, err)
+			}
+			if got.Word != want {
+				t.Errorf("One(%q): Word = %q, want %q", input, got.Word, want)
+			}
+		}
+	})
+
+	t.Run("All decodes mixed branches", func(t *testing.T) {
+		got, err := dec.All("xa yb")
+		if err != nil {
+			t.Fatalf("All: %v", err)
+		}
+		if len(got) != 2 || got[0].Word != "a" || got[1].Word != "b" {
+			t.Errorf("got %+v, want [{a} {b}]", got)
+		}
+	})
+
+	t.Run("sequential duplicates agree with Unmarshal (last wins)", func(t *testing.T) {
+		const pattern = `(?P<word>\w+) (?P<word>\w+)`
+		seqDec := MustCompile[rec](pattern)
+		fromDecoder, err := seqDec.One("hello world")
+		if err != nil {
+			t.Fatalf("One: %v", err)
+		}
+		var fromUnmarshal rec
+		if err := Unmarshal(regexp.MustCompile(pattern), "hello world", &fromUnmarshal); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if fromDecoder.Word != fromUnmarshal.Word {
+			t.Errorf("paths disagree: Decoder=%q Unmarshal=%q", fromDecoder.Word, fromUnmarshal.Word)
+		}
+		if fromDecoder.Word != "world" {
+			t.Errorf("Word = %q, want %q", fromDecoder.Word, "world")
+		}
+	})
+}
+
+func TestFindNamed_duplicateNames(t *testing.T) {
+	re := regexp.MustCompile(`(?:x(?P<word>a)|y(?P<word>b))`)
+
+	if got, ok := FindNamed(re, "yb", "word"); got != "b" || !ok {
+		t.Errorf(`FindNamed("yb","word") = (%q,%v), want ("b",true) — must read the participating branch, not SubexpIndex's first`, got, ok)
+	}
+	if got, ok := FindNamed(re, "xa", "word"); got != "a" || !ok {
+		t.Errorf(`FindNamed("xa","word") = (%q,%v), want ("a",true)`, got, ok)
+	}
+	if got, ok := FindNamed(re, "zz", "word"); ok {
+		t.Errorf(`FindNamed("zz","word") = (%q,%v), want ("",false) on no match`, got, ok)
+	}
+	if got, ok := FindNamed(re, "yb", "missing"); ok {
+		t.Errorf(`FindNamed("yb","missing") = (%q,%v), want ("",false) for an undeclared group`, got, ok)
+	}
+}
+
+func TestFindAllNamed_duplicateNames(t *testing.T) {
+	re := regexp.MustCompile(`(?:x(?P<word>a)|y(?P<word>b))`)
+	got := FindAllNamed(re, "xa yb", "word")
+	want := []string{"a", "b"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("FindAllNamed(%q) = %q, want %q (each match reads its participating branch)", "xa yb", got, want)
+	}
+}
+
+// Issue-105 follow-up: when a duplicate group name's last occurrence
+// participates with an *empty* span, the Decoder and the Unmarshal/NamedGroups
+// paths must agree (the Decoder previously read the first occurrence's value).
+func TestDecoderUnmarshal_participatingEmptyDuplicate(t *testing.T) {
+	const pattern = `(?P<word>a)(?P<word>b*)`
+	re := regexp.MustCompile(pattern)
+	type rec struct {
+		Word string `regex:"word"`
+	}
+
+	dec := MustCompile[rec](pattern)
+	fromDecoder, err := dec.One("a")
+	if err != nil {
+		t.Fatalf("One: %v", err)
+	}
+	fromMap := NamedGroups(re, "a")["word"]
+	var fromUnmarshal rec
+	if err := Unmarshal(re, "a", &fromUnmarshal); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if fromDecoder.Word != fromMap || fromDecoder.Word != fromUnmarshal.Word {
+		t.Errorf("paths disagree: Decoder=%q NamedGroups=%q Unmarshal=%q (want all equal)",
+			fromDecoder.Word, fromMap, fromUnmarshal.Word)
+	}
+	if fromDecoder.Word != "" {
+		t.Errorf("Word = %q, want \"\" (the empty b* span is the last participating occurrence)", fromDecoder.Word)
+	}
+}
+
+// A non-participating optional group on a typed field is left at its zero value
+// by both paths; Unmarshal no longer errors trying to convert "" (issue-105
+// alignment of the Unmarshal and Decoder paths).
+func TestUnmarshalDecoder_nonParticipatingOptionalTyped(t *testing.T) {
+	const pattern = `y(?P<num>\d+)?`
+	re := regexp.MustCompile(pattern)
+	type rec struct {
+		Num int `regex:"num"`
+	}
+
+	var fromUnmarshal rec
+	if err := Unmarshal(re, "y", &fromUnmarshal); err != nil {
+		t.Fatalf("Unmarshal: unexpected error %v (a non-participating optional group should leave the field zero)", err)
+	}
+	if fromUnmarshal.Num != 0 {
+		t.Errorf("Unmarshal Num = %d, want 0", fromUnmarshal.Num)
+	}
+
+	dec := MustCompile[rec](pattern)
+	fromDecoder, err := dec.One("y")
+	if err != nil {
+		t.Fatalf("One: %v", err)
+	}
+	if fromDecoder.Num != 0 {
+		t.Errorf("Decoder Num = %d, want 0", fromDecoder.Num)
+	}
+}
+
+// NamedGroups still surfaces a declared-but-non-participating group as "" —
+// only the Unmarshal path omits it (the includeNonParticipating split).
+func TestNamedGroups_nonParticipatingStillPresent(t *testing.T) {
+	re := regexp.MustCompile(`(?:x(?P<a>1)|y(?P<b>2))`)
+	got := NamedGroups(re, "y2")
+	if v, ok := got["a"]; !ok || v != "" {
+		t.Errorf(`NamedGroups("y2")["a"] = (%q,%v), want ("",true) — declared but did not participate`, v, ok)
+	}
+	if got["b"] != "2" {
+		t.Errorf(`NamedGroups("y2")["b"] = %q, want "2"`, got["b"])
+	}
+}

--- a/regextra.go
+++ b/regextra.go
@@ -182,32 +182,43 @@ import (
 // FindNamed returns the value of the named capture group in the target string.
 // It returns the matched value and true if found, or empty string and false if not found.
 //
+// When the pattern reuses a group name (e.g. across alternation branches),
+// FindNamed returns the value of the last occurrence that participated in the
+// match — it does not trust re.SubexpIndex, which reports only the first
+// occurrence and would return the wrong value when a later branch is the one
+// that matched.
+//
 // Example:
 //
 //	re := regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
 //	name, ok := regextra.FindNamed(re, "Alice 30", "name")
 //	// name = "Alice", ok = true
 func FindNamed(re *regexp.Regexp, target, groupName string) (string, bool) {
-	index := re.SubexpIndex(groupName)
-	if index == -1 {
+	idxs := subexpIndexes(re, groupName)
+	if len(idxs) == 0 {
 		return "", false
 	}
 
-	// FindStringSubmatchIndex returns only the match offsets ([]int), so we can
-	// slice the one group we want out of target directly. FindStringSubmatch
+	// FindStringSubmatchIndex returns only the match offsets ([]int), so we
+	// slice the participating group out of target directly. FindStringSubmatch
 	// would additionally allocate a []string for every group just to discard
 	// all but one.
 	loc := re.FindStringSubmatchIndex(target)
 	if loc == nil {
 		return "", false
 	}
-	start, end := loc[2*index], loc[2*index+1]
-	if start < 0 {
-		// Group is declared but did not participate in the match; regexp's
-		// FindStringSubmatch would surface this as "" — preserve that.
-		return "", true
+	// A pattern may reuse a group name (e.g. across alternation branches); the
+	// last occurrence that participated in the match wins, and a
+	// non-participating occurrence is skipped. If no occurrence participated,
+	// value stays "" — matching FindStringSubmatch's "" for a declared but
+	// non-participating group.
+	value := ""
+	for _, idx := range idxs {
+		if start := loc[2*idx]; start >= 0 {
+			value = target[start:loc[2*idx+1]]
+		}
 	}
-	return target[start:end], true
+	return value, true
 }
 
 // FindAllNamed returns every value of the named capture group across all
@@ -226,25 +237,31 @@ func FindNamed(re *regexp.Regexp, target, groupName string) (string, bool) {
 // use [AllNamedGroups]. Despite the "All" prefix, AllNamedGroups operates on
 // a single match — it does not iterate matches across the target the way
 // FindAllNamed does.
+//
+// When the pattern reuses a group name, each match contributes the value of
+// the occurrence that participated in that match, not blindly re.SubexpIndex's
+// first occurrence.
 func FindAllNamed(re *regexp.Regexp, target, groupName string) []string {
-	index := re.SubexpIndex(groupName)
-	if index == -1 {
+	idxs := subexpIndexes(re, groupName)
+	if len(idxs) == 0 {
 		return nil
 	}
-	// Index form returns []int offsets per match; we slice the single group out
-	// of target rather than have FindAllStringSubmatch build a [][]string of
-	// every group across every match only to read one column of it.
+	// Index form returns []int offsets per match; we slice the participating
+	// group out of target rather than have FindAllStringSubmatch build a
+	// [][]string of every group across every match only to read one column.
 	locs := re.FindAllStringSubmatchIndex(target, -1)
 	if len(locs) == 0 {
 		return []string{}
 	}
 	out := make([]string, len(locs))
 	for i, loc := range locs {
-		if s := loc[2*index]; s >= 0 {
-			out[i] = target[s:loc[2*index+1]]
+		// Last participating occurrence of the name in this match wins; a
+		// non-participating occurrence is skipped, leaving out[i] == "".
+		for _, idx := range idxs {
+			if start := loc[2*idx]; start >= 0 {
+				out[i] = target[start:loc[2*idx+1]]
+			}
 		}
-		// s < 0 → group did not participate in this match; leave out[i] == ""
-		// to match FindStringSubmatch's "" for a non-participating group.
 	}
 	return out
 }
@@ -252,26 +269,78 @@ func FindAllNamed(re *regexp.Regexp, target, groupName string) []string {
 // NamedGroups returns a map of all named capture groups and their matched values
 // from the target string. If no match is found, it returns an empty map.
 //
+// When the pattern reuses a group name (e.g. across alternation branches),
+// the value of the last occurrence that participated in the match wins; an
+// occurrence that did not participate never overwrites a participating
+// occurrence's value. A declared group that did not participate at all is
+// still present in the map, mapped to "".
+//
+// To see every occurrence rather than just the winning one, use
+// [AllNamedGroups] — but note it reports a non-participating occurrence and an
+// occurrence that matched an empty span identically (both as ""), so it cannot
+// be used to tell those two cases apart.
+//
 // Example:
 //
 //	re := regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
 //	groups := regextra.NamedGroups(re, "Alice 30")
 //	// groups = map[string]string{"name": "Alice", "age": "30"}
 func NamedGroups(re *regexp.Regexp, target string) map[string]string {
-	result := make(map[string]string)
-
-	matches := re.FindStringSubmatch(target)
-	if matches == nil {
-		return result
+	m := re.FindStringSubmatchIndex(target)
+	if m == nil {
+		return make(map[string]string)
 	}
+	// includeNonParticipating: NamedGroups surfaces every declared group,
+	// including ones that did not participate (mapped to ""). The Unmarshal
+	// path passes false so those don't reach typed-field conversion as "".
+	return namedGroupValues(re, target, m, true)
+}
 
-	for i, name := range re.SubexpNames() {
-		if i != 0 && name != "" {
-			result[name] = matches[i]
-		}
-	}
-
+// namedGroupValues builds the group-name→value map for one match, given the
+// match's index pairs from FindStringSubmatchIndex (or one element of
+// FindAllStringSubmatchIndex). Index pairs distinguish "did not participate"
+// (negative indices) from "matched an empty span", so when a pattern reuses a
+// group name a participating occurrence always wins and a non-participating
+// occurrence never clobbers it.
+//
+// includeNonParticipating controls what happens to a group name that never
+// participated in the match:
+//   - true ([NamedGroups]): the name is recorded as "" so callers see every
+//     declared group.
+//   - false (the [Unmarshal] / [UnmarshalAll] path): the name is omitted, so
+//     a non-participating optional group looks like "no value" to
+//     populateStruct — it is left at its zero value rather than handed "",
+//     which would fail conversion on a typed field. A duplicate that
+//     participates elsewhere still sets the key, so omitting here never drops
+//     a real value.
+func namedGroupValues(re *regexp.Regexp, target string, m []int, includeNonParticipating bool) map[string]string {
+	names := re.SubexpNames()
+	result := make(map[string]string, len(names))
+	fillNamedGroupValues(result, names, target, m, includeNonParticipating)
 	return result
+}
+
+// fillNamedGroupValues writes one match's group-name→value pairs into dst,
+// which the caller has already cleared. names is re.SubexpNames(), passed in so
+// a caller decoding many matches (UnmarshalAll) fetches it once and reuses one
+// map instead of allocating per match. m is the match's index pairs; see
+// [namedGroupValues] for the participation semantics and includeNonParticipating.
+func fillNamedGroupValues(dst map[string]string, names []string, target string, m []int, includeNonParticipating bool) {
+	for i, name := range names {
+		if i == 0 || name == "" {
+			continue
+		}
+		start, end := m[2*i], m[2*i+1]
+		if start < 0 {
+			if includeNonParticipating {
+				if _, ok := dst[name]; !ok {
+					dst[name] = ""
+				}
+			}
+			continue
+		}
+		dst[name] = target[start:end]
+	}
 }
 
 // AllNamedGroups operates on a single match and returns every value of every

--- a/regextra_test.go
+++ b/regextra_test.go
@@ -26,11 +26,16 @@ func TestFindNamed(t *testing.T) {
 			wantFound: true,
 		},
 		{
-			name:      "found second group",
+			// Two `second` groups, both participating: the last occurrence
+			// wins, consistent with NamedGroups (see TestNamedGroups,
+			// "duplicate names return last match"). FindNamed used to return
+			// the first occurrence ("two") via re.SubexpIndex; that disagreed
+			// with every other name-based reader and is the issue-105 bug.
+			name:      "found second group (duplicate name: last participating wins)",
 			pattern:   `(?P<first>one) (?P<second>two) (?P<second>again) three`,
 			target:    "one two again three",
 			groupName: "second",
-			want:      "two",
+			want:      "again",
 			wantFound: true,
 		},
 		{

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -87,22 +87,19 @@ func Unmarshal(re *regexp.Regexp, target string, v any) error {
 		return fmt.Errorf("regextra: Unmarshal requires a pointer to a struct, got pointer to %s", elem.Kind())
 	}
 
-	// Find the match
-	matches := re.FindStringSubmatch(target)
+	// Find the match. The Index variant distinguishes non-participating
+	// group occurrences from empty matches, which namedGroupValues needs to
+	// handle duplicate group names correctly.
+	matches := re.FindStringSubmatchIndex(target)
 	if matches == nil {
 		return nil // No match, but not an error
 	}
 
-	// Build a map of capture group names to their values
-	groupValues := make(map[string]string)
-	for i, name := range re.SubexpNames() {
-		if i != 0 && name != "" {
-			groupValues[name] = matches[i]
-		}
-	}
-
-	// Populate the struct fields
-	return populateStruct(elem, groupValues)
+	// Populate the struct fields. includeNonParticipating=false: a declared
+	// optional group that did not participate in the match is omitted rather
+	// than recorded as "", so populateStruct leaves the field at its zero
+	// value instead of feeding "" to a typed conversion (which would error).
+	return populateStruct(elem, namedGroupValues(re, target, matches, false))
 }
 
 // UnmarshalAll extracts all occurrences of the regex pattern from the target string
@@ -141,8 +138,10 @@ func UnmarshalAll(re *regexp.Regexp, target string, v any) error {
 		return fmt.Errorf("regextra: UnmarshalAll requires a slice of structs, got slice of %s", sliceElemType.Kind())
 	}
 
-	// Find all matches
-	allMatches := re.FindAllStringSubmatch(target, -1)
+	// Find all matches. The Index variant distinguishes non-participating
+	// group occurrences from empty matches, which namedGroupValues needs to
+	// handle duplicate group names correctly.
+	allMatches := re.FindAllStringSubmatchIndex(target, -1)
 	if len(allMatches) == 0 {
 		// Clear the slice and return (no matches is not an error)
 		elem.SetLen(0)
@@ -153,17 +152,16 @@ func UnmarshalAll(re *regexp.Regexp, target string, v any) error {
 	// match. Reuse a single groupValues map (cleared each iteration) rather than
 	// allocating one per match, and size the result slice up front so each match
 	// decodes into place — avoiding the reflect.New + reflect.Append copy the
-	// previous append-grow loop paid per match.
+	// append-grow loop paid per match.
 	names := re.SubexpNames()
 	newSlice := reflect.MakeSlice(elem.Type(), len(allMatches), len(allMatches))
 	groupValues := make(map[string]string, len(names))
 	for idx, matches := range allMatches {
+		// includeNonParticipating=false (see Unmarshal): a non-participating
+		// optional group is omitted so its typed field stays zero, and the
+		// participating occurrence of a reused name wins.
 		clear(groupValues)
-		for i, name := range names {
-			if i != 0 && name != "" {
-				groupValues[name] = matches[i]
-			}
-		}
+		fillNamedGroupValues(groupValues, names, target, matches, false)
 		if err := populateStruct(newSlice.Index(idx), groupValues); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #105.

Patterns that reuse a group name (e.g. `(?:x(?P<word>a)|y(?P<word>b))`) were mishandled in opposite directions by the two paths:

- **NamedGroups / Unmarshal / UnmarshalAll** built their name→value map by iterating every group, so a non-participating later occurrence clobbered the real value with `""` — matching `"xa"` yielded `map[word:""]`.
- **Decoder** resolved each field via `SubexpIndex`, which reports only the *first* occurrence — decoding `"yb"` yielded a zero `Word`.

Changes:

- New shared `namedGroupValues` helper builds the map from `FindStringSubmatchIndex` pairs, which distinguish "did not participate" (negative indices) from "matched an empty span". A non-participating occurrence records `""` only if the name has no value yet. `NamedGroups`, `Unmarshal`, and `UnmarshalAll` all use it — this also collapses the map-building loop that was copy-pasted three times (a slice of the #108 refactor).
- `fieldDecoder` now precomputes `groupIndexes []int` (every occurrence, via new `subexpIndexes`) instead of a single `groupIndex`; `decode` scans them, last non-empty occurrence wins — same semantics as the map path. The dead `|| fd.groupIndex == 0` condition flagged in #109 disappears with the rewrite.

Semantics for *multiple participating* duplicates (sequential like `(?P<word>\w+) (?P<word>\w+)`) stay last-wins, now pinned by tests in both paths. `AllNamedGroups` is intentionally untouched — preserving every occurrence is its documented job, also pinned.

Tests: new `duplicate_groups_test.go` covering both alternation branches through `NamedGroups`, `Unmarshal`, `UnmarshalAll`, `Decoder.One`/`All`, sequential-duplicate last-wins parity, and `AllNamedGroups` preservation. Benchmarks still pass.

CHANGELOG entry deferred to release prep to keep the parallel fix PRs conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected decoding for regexes with the same named capture group repeated, so the resolved value is consistent across occurrences.
  * Fixed unmarshal behavior for optional typed groups: non-participating groups no longer cause errors and remain unset.
  * Improved named-group value handling for empty vs non-participating matches, including in named-group enumeration.
* **Performance**
  * Reduced allocation overhead during decoding and unmarshal by using index-based matching to distinguish participating vs non-participating groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->