### PR TITLE
perf: benchmark suite + allocation cuts in Replace/Find*/UnmarshalAll (fixes #107)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -11,8 +11,13 @@ permissions:
 jobs:
   tag-and-release:
     name: Tag and create GitHub Release
-    # Only run if the PR was merged and the head branch is a release/* branch.
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    # Only run for a merged release/* PR that originated from this repo (not a
+    # fork). Release branches are maintainer-created in the base repo, and a
+    # fork PR couldn't push a tag anyway (read-only token), so gate it out.
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:
@@ -32,10 +37,14 @@ jobs:
 
       - name: Extract version from branch name
         id: extract_version
+        # HEAD_REF arrives via env, not ${{ }} interpolation into the script, so
+        # a branch name with shell metacharacters can't inject commands. The
+        # value is still validated against vX.Y.Z below before any use.
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          VERSION="${BRANCH_NAME#release/}"
+          VERSION="${HEAD_REF#release/}"
           if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Invalid version format: $VERSION (expected vX.Y.Z, e.g. v0.3.0)"
             exit 1
@@ -81,8 +90,9 @@ jobs:
         # when the branch is already gone.
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          BRANCH=$(gh pr view ${{ github.event.pull_request.number }} --json headRefName -q .headRefName)
+          BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName -q .headRefName)
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
             git push origin --delete "$BRANCH"
             echo "✅ Deleted release branch: $BRANCH"

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -86,16 +86,25 @@ jobs:
 
       - name: Delete release branch (best effort)
         # GitHub auto-deletes merged branches if the repo has that setting
-        # enabled, so this is a no-op in that case. Don't fail the workflow
-        # when the branch is already gone.
+        # enabled, so this is usually a no-op. Strictly best-effort: never fail
+        # the release over branch cleanup — the tag and GitHub Release are
+        # already published by this point.
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName -q .headRefName)
-          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            git push origin --delete "$BRANCH"
+          BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName -q .headRefName) || {
+            echo "::warning::Could not resolve the release branch for PR #$PR_NUMBER; skipping cleanup"
+            exit 0
+          }
+          if [ -z "$BRANCH" ]; then
+            echo "::warning::Release branch name was empty; skipping cleanup"
+            exit 0
+          fi
+          if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "ℹ️  Release branch $BRANCH already removed (likely auto-deleted on merge)"
+          elif git push origin --delete "$BRANCH"; then
             echo "✅ Deleted release branch: $BRANCH"
           else
-            echo "ℹ️  Release branch $BRANCH already removed (likely auto-deleted on merge)"
+            echo "::warning::Failed to delete release branch $BRANCH (tag and release are already published)"
           fi

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,68 @@
+name: Benchmarks
+
+# Runs the benchmark suite (bench_*.go) on the newest supported toolchain. The
+# point is twofold: (1) keep the benchmarks compiling and runnable — a broken
+# or panicking benchmark fails this job; (2) surface the numbers in the job
+# summary so a PR's effect on the hot paths is visible at review time.
+#
+# This job does NOT gate on performance thresholds. GitHub-hosted runners are
+# shared and noisy, so absolute ns/op swings are not reliable enough to fail a
+# build on. For a real before/after, run the suite locally and diff with
+# benchstat (see the header of bench_test.go).
+#
+# Note: testing ACROSS toolchains lives in test.yml's matrix (1.24/1.25/1.26);
+# this workflow is specifically the performance leg on the latest toolchain.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: Benchmarks (Go 1.26)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+      with:
+        go-version: '1.26'
+
+    - name: Get dependencies
+      run: go mod download
+
+    - name: Run benchmarks
+      run: |
+        set -euo pipefail
+        # Modest -benchtime/-count: enough to exercise every case and catch a
+        # broken benchmark, while keeping the job fast. These numbers are a
+        # smoke signal and a record, not a gating threshold (see header).
+        go test -run='^$' -bench=. -benchmem -benchtime=50ms -count=3 ./... | tee bench.txt
+
+    - name: Publish results to job summary
+      if: always()
+      run: |
+        {
+          echo "## Benchmark results (Go 1.26)"
+          echo ""
+          echo "Smoke run on a shared runner — informational, not a perf gate."
+          echo "For before/after, diff locally with benchstat."
+          echo ""
+          echo '```'
+          if [ -f bench.txt ]; then
+            grep -E '^(goos|goarch|pkg|cpu|Benchmark)' bench.txt || cat bench.txt
+          else
+            echo "(benchmark run produced no output)"
+          fi
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,6 +26,10 @@ permissions:
 jobs:
   benchmark:
     name: Benchmarks (Go 1.26)
+    # Don't run on fork PRs (no token/secret exposure); same-repo + push still run.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -32,6 +32,10 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      with:
+        # Read-only checkout: don't leave the token in local git config where
+        # benchmark/test code (PR-controlled) could reach it.
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,10 @@ concurrency:
 jobs:
   analyze:
     name: Analyze (Go)
+    # Don't run on fork PRs (no token/secret exposure); same-repo + push/schedule still run.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          # Read-only checkout: don't leave the token in local git config where
+          # PR-controlled code (go build) could reach it.
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -19,6 +19,10 @@ concurrency:
 jobs:
   govulncheck:
     name: govulncheck
+    # Don't run on fork PRs (no token/secret exposure); same-repo + push/schedule still run.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -25,6 +25,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          # Read-only checkout: don't leave the token in local git config where
+          # PR-controlled code (govulncheck builds the module) could reach it.
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,10 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      with:
+        # Read-only checkout: don't leave the token in local git config where
+        # PR-controlled code (go test/vet/lint) could reach it.
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
@@ -81,6 +85,10 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      with:
+        # Read-only checkout: don't leave the token in local git config where
+        # PR-controlled code (go test/vet/lint) could reach it.
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
@@ -101,6 +109,10 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      with:
+        # Read-only checkout: don't leave the token in local git config where
+        # PR-controlled code (go test/vet/lint) could reach it.
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ permissions:
 jobs:
   test:
     name: Test (Go ${{ matrix.go-version }})
+    # Don't run on fork PRs (no token/secret exposure); same-repo + push still run.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -80,6 +84,9 @@ jobs:
 
   lint:
     name: Lint
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     
     steps:
@@ -104,6 +111,9 @@ jobs:
 
   vet:
     name: Vet
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
       with:
-        file: ./coverage.txt
+        files: ./coverage.txt
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false

--- a/bench_decoder_test.go
+++ b/bench_decoder_test.go
@@ -1,0 +1,149 @@
+package regextra_test
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	rx "github.com/jecoms/regextra"
+)
+
+// Typed sinks for the decode results (assigning a struct/slice to `any` would
+// box-allocate and pollute allocs/op; a typed sink stores the value directly).
+var (
+	sinkSimpleSlice []benchSimple
+	sinkInt         int
+)
+
+// ── Compile / MustCompile ─────────────────────────────────────────────────────
+//
+// Cost model: regexp.Compile plus a reflect plan build — per exported field:
+// parseFieldTag, SubexpIndex, an eager default= probe via setFieldValue, and
+// layout= validation. For simple patterns regexp.Compile DOMINATES and hides
+// the per-field work, so two isolation harnesses accompany the headline cases:
+//   - regexpCompileBaseline: stdlib regexp.Compile of the SAME pattern; the
+//     benchstat subtrahend that exposes the reflect/plan cost Decoder caches.
+//   - fields1/10/20: a FIXED trivial pattern with varying field count, so the
+//     delta across N is pure per-field plan cost with regexp.Compile constant.
+// (A third, cleaner isolation that excludes regexp.Compile entirely lives in
+// bench_internal_test.go, which can reach the unexported compileDecoder.)
+
+type benchThreeDefaults struct {
+	A string `regex:"a,default=x"`
+	B int    `regex:"b,default=7"`
+	C string `regex:"c,default=z"`
+}
+
+const benchThreeDefaultsPattern = `(?P<a>\w+) (?P<b>\d+) (?P<c>\w+)`
+
+type benchLayoutCompile struct {
+	TS time.Time `regex:"ts,layout=2006-01-02"`
+}
+
+const benchLayoutCompilePattern = `(?P<ts>\S+)`
+
+// Fixed trivial pattern; every field maps to the one declared group so field
+// count varies while regexp.Compile cost stays constant.
+const benchFixedPattern = `(?P<g>\w+)`
+
+type benchFields1 struct {
+	F0 string `regex:"g"`
+}
+
+type benchFields10 struct {
+	F0, F1, F2, F3, F4, F5, F6, F7, F8, F9 string `regex:"g"`
+}
+
+type benchFields20 struct {
+	F0, F1, F2, F3, F4, F5, F6, F7, F8, F9 string `regex:"g"`
+	G0, G1, G2, G3, G4, G5, G6, G7, G8, G9 string `regex:"g"`
+}
+
+func BenchmarkCompile(b *testing.B) {
+	// representative — typical compile shapes.
+	benchCase(b, "simpleStruct", func() { d, err := rx.Compile[benchSimple](benchSimplePattern); sinkAny, sinkErr = d, err })
+	benchCase(b, "wideStruct", func() { d, err := rx.Compile[benchWide](benchWidePattern); sinkAny, sinkErr = d, err })
+	benchCase(b, "threeDefaults", func() { d, err := rx.Compile[benchThreeDefaults](benchThreeDefaultsPattern); sinkAny, sinkErr = d, err })
+	benchCase(b, "timeFieldWithLayout", func() { d, err := rx.Compile[benchLayoutCompile](benchLayoutCompilePattern); sinkAny, sinkErr = d, err })
+	// isolation — subtract this from simpleStruct to get the plan-build cost.
+	benchCase(b, "regexpCompileBaseline", func() { re, err := regexp.Compile(benchSimplePattern); sinkAny, sinkErr = re, err })
+	// fixed-pattern field-count sweep — slope is pure per-field plan cost.
+	benchCase(b, "fields1", func() { d, err := rx.Compile[benchFields1](benchFixedPattern); sinkAny, sinkErr = d, err })
+	benchCase(b, "fields10", func() { d, err := rx.Compile[benchFields10](benchFixedPattern); sinkAny, sinkErr = d, err })
+	benchCase(b, "fields20", func() { d, err := rx.Compile[benchFields20](benchFixedPattern); sinkAny, sinkErr = d, err })
+	// symbol coverage — MustCompile's nil-check + not-taken panic over Compile.
+	benchCase(b, "mustCompile", func() { sinkAny = rx.MustCompile[benchSimple](benchSimplePattern) })
+}
+
+// ── Decoder.One / .All / .Iter / .Pattern ─────────────────────────────────────
+//
+// The cached hot path: decode walks a precomputed field plan against the match,
+// with no per-call reflect of the destination type. Decoders are compiled once
+// (package-level) so the loop measures decode, not Compile. The decoded value is
+// discarded (sinking it to `any` would box-allocate); b.Loop keeps the call.
+
+var (
+	benchSimpleDecoder  = rx.MustCompile[benchSimple](benchSimplePattern)
+	benchTimeDecoder    = rx.MustCompile[benchTime](`(?P<ts>\S+) \((?P<took>\S+)\)`)
+	benchDefaultDecoder = rx.MustCompile[benchDefault](`(?P<name>\w+)`)
+	benchCustomDecoder  = rx.MustCompile[benchCustom](`\[(?P<state>\w+)\]`)
+	benchWideDecoder    = rx.MustCompile[benchWide](benchWidePattern)
+	benchLogDecoder     = rx.MustCompile[benchLogLine](`\[(?P<level>\w+)\] (?P<msg>[^\n]+)`)
+)
+
+func BenchmarkDecoderOne(b *testing.B) {
+	// simple pairs with BenchmarkUnmarshal/simpleThreeField (identical fixtures).
+	benchCase(b, "simple", func() { _, sinkErr = benchSimpleDecoder.One(benchSimpleInput) })
+	benchCase(b, "noMatch", func() { _, sinkErr = benchSimpleDecoder.One(benchNoMatchInput) }) // ErrNoMatch sentinel
+	benchCase(b, "withTime", func() { _, sinkErr = benchTimeDecoder.One(benchTimeFirstIn) })
+	benchCase(b, "timeLastLayout", func() { _, sinkErr = benchTimeDecoder.One(benchTimeLastIn) }) // fallback-list worst case
+	benchCase(b, "withDefault", func() { _, sinkErr = benchDefaultDecoder.One(benchDefaultIn) })
+	benchCase(b, "customType", func() { _, sinkErr = benchCustomDecoder.One(benchCustomIn) })
+	benchCase(b, "manyFields", func() { _, sinkErr = benchWideDecoder.One(benchWideInput) })
+}
+
+func BenchmarkDecoderAll(b *testing.B) {
+	benchCase(b, "noMatch", func() { sinkSimpleSlice, sinkErr = benchSimpleDecoder.All(benchNoMatchInput) })
+	benchCase(b, "singleMatch", func() { sinkSimpleSlice, sinkErr = benchSimpleDecoder.All(benchSimpleInput) })
+	benchCase(b, "matches10", func() { sinkSimpleSlice, sinkErr = benchSimpleDecoder.All(benchBatch10Input) })
+	// matches100 pairs with BenchmarkUnmarshalAll/matches100 (identical fixtures).
+	benchCase(b, "matches100", func() { sinkSimpleSlice, sinkErr = benchSimpleDecoder.All(benchBatch100Input) })
+	benchCase(b, "matches1000", func() { sinkSimpleSlice, sinkErr = benchSimpleDecoder.All(benchBatch1000Input) })
+}
+
+func BenchmarkDecoderIter(b *testing.B) {
+	// fullIteration decodes all 100 lines (pairs with BenchmarkUnmarshalAll/realisticLogCorpus
+	// in input, but skips the result-slice allocation).
+	benchCase(b, "fullIteration", func() {
+		n := 0
+		for _, err := range benchLogDecoder.Iter(benchLogIn) {
+			sinkErr = err
+			n++
+		}
+		sinkInt = n
+	})
+	// earlyBreak shows the lazy-decode benefit: 100 matches found, only 5 decoded.
+	benchCase(b, "earlyBreak", func() {
+		n := 0
+		for _, err := range benchLogDecoder.Iter(benchLogIn) {
+			sinkErr = err
+			n++
+			if n >= 5 {
+				break
+			}
+		}
+		sinkInt = n
+	})
+	benchCase(b, "noMatch", func() {
+		n := 0
+		for _, err := range benchLogDecoder.Iter(benchNoMatchInput) {
+			sinkErr = err
+			n++
+		}
+		sinkInt = n
+	})
+}
+
+func BenchmarkDecoderPattern(b *testing.B) {
+	benchCase(b, "pattern", func() { sinkStr = benchSimpleDecoder.Pattern() })
+}

--- a/bench_internal_test.go
+++ b/bench_internal_test.go
@@ -1,0 +1,37 @@
+package regextra
+
+import (
+	"regexp"
+	"testing"
+)
+
+// Internal benchmark (package regextra, not regextra_test) so it can call the
+// unexported compileDecoder. This is the cleanest isolation of the compile-side
+// work Decoder caching eliminates: regexp.Compile is done ONCE before the loop
+// (package-level bnInternalRe), so the loop measures only reflect.TypeOf + the
+// per-field plan build (parseFieldTag, SubexpIndex, eager default probe).
+//
+// Compare against BenchmarkCompile/regexpCompileBaseline (the regexp.Compile
+// cost) and BenchmarkCompile/simpleStruct (the two combined) in
+// bench_decoder_test.go.
+
+type bnInternalSimple struct {
+	Name   string `regex:"name"`
+	Age    int    `regex:"age"`
+	Active bool   `regex:"active"`
+}
+
+const bnInternalPattern = `(?P<name>\w+) is (?P<age>\d+) (?P<active>\w+)`
+
+var bnInternalRe = regexp.MustCompile(bnInternalPattern)
+
+func BenchmarkCompilePlanOnly(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		d, err := compileDecoder[bnInternalSimple](bnInternalPattern, bnInternalRe)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = d
+	}
+}

--- a/bench_replace_validate_test.go
+++ b/bench_replace_validate_test.go
@@ -84,8 +84,8 @@ var (
 )
 
 func BenchmarkValidate(b *testing.B) {
-	benchCase(b, "allPresentSmall", func() { sinkErr = rx.Validate(bnValRe, bnValPresent...) })     // nil, no missing-list alloc
-	benchCase(b, "partialMissSmall", func() { sinkErr = rx.Validate(bnValRe, bnValPartial...) })    // 1 missing
+	benchCase(b, "allPresentSmall", func() { sinkErr = rx.Validate(bnValRe, bnValPresent...) })        // nil, no missing-list alloc
+	benchCase(b, "partialMissSmall", func() { sinkErr = rx.Validate(bnValRe, bnValPartial...) })       // 1 missing
 	benchCase(b, "allPresentMany", func() { sinkErr = rx.Validate(bnValManyRe, bnValManyPresent...) }) // 20-name set build + 20 hits
 	benchCase(b, "allMissingMany", func() { sinkErr = rx.Validate(bnValManyRe, bnValManyMissing...) }) // 20 misses + big Join
 	benchCase(b, "noDeclaredSomeRequired", func() { sinkErr = rx.Validate(bnValEmptyRe, bnValSome...) })

--- a/bench_replace_validate_test.go
+++ b/bench_replace_validate_test.go
@@ -1,0 +1,93 @@
+package regextra_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	rx "github.com/jecoms/regextra"
+)
+
+// ── Replace ───────────────────────────────────────────────────────────────────
+//
+// Cost model: an empty replacements map returns before any scan. Otherwise
+// FindAllStringSubmatchIndex scans the whole target and allocates the index
+// matrix; then per match a span slice is built, sort.Slice-d by start, and
+// written to a strings.Builder with cursor tracking for the outermost-wins
+// overlap rule. Cost dimensions: match count, named-groups-per-match (sort
+// size), and replacement length (Builder growth).
+//
+// Note: the nestedGroups case exercises the documented "outermost wins" path,
+// which issue #107 shows is not guaranteed because sort.Slice is unstable. This
+// benchmark measures the path's cost; it does not assert the tie-break.
+
+var (
+	bnRepEmailRe     = regexp.MustCompile(`(?P<user>\w+)@(?P<domain>[\w.]+)`)
+	bnRepSingleIn    = "alice@example.com"
+	bnRepDomainMap   = map[string]string{"domain": "redacted"}
+	bnRepBothMap     = map[string]string{"user": "anon", "domain": "redacted"}
+	bnRepEmptyMap    = map[string]string{}
+	bnRepMissMap     = map[string]string{"nonexistent": "x"}
+	bnRepNoMatchIn   = "no matches here at all, just plain words"
+	bnRepMulti100In  = strings.TrimSpace(strings.Repeat("alice@example.com ", 100))
+	bnRepMulti1200In = strings.TrimSpace(strings.Repeat("alice@example.com ", 1200))
+	bnRepNestRe      = regexp.MustCompile(`(?P<outer>(?P<inner>\w+)@[\w.]+)`)
+	bnRepNestMap     = map[string]string{"outer": "X", "inner": "Y"}
+	bnRepOptRe       = regexp.MustCompile(`(?P<word>\w+)(?P<bang>!)?`)
+	bnRepOptIn       = "hello world foo bar baz"
+	bnRepOptMap      = map[string]string{"word": "W", "bang": "B"}
+	bnRepManyGRe     = regexp.MustCompile(bnGroupsPattern(8))
+	bnRepManyGIn     = bnWords(8)
+	bnRepManyGMap    = map[string]string{"f0": "a", "f1": "b", "f2": "c", "f3": "d", "f4": "e", "f5": "f", "f6": "g", "f7": "h"}
+	bnRepLongMap     = map[string]string{"domain": strings.Repeat("x", 200)}
+)
+
+func BenchmarkReplace(b *testing.B) {
+	// representative — one match, then a realistic 100-match batch.
+	benchCase(b, "singleGroup", func() { sinkStr = rx.Replace(bnRepEmailRe, bnRepSingleIn, bnRepDomainMap) })
+	benchCase(b, "twoGroups", func() { sinkStr = rx.Replace(bnRepEmailRe, bnRepSingleIn, bnRepBothMap) })
+	benchCase(b, "matches100", func() { sinkStr = rx.Replace(bnRepEmailRe, bnRepMulti100In, bnRepDomainMap) })
+	// edge — the two early returns and the loop-with-zero-spans passthrough.
+	benchCase(b, "emptyReplacements", func() { sinkStr = rx.Replace(bnRepEmailRe, bnRepSingleIn, bnRepEmptyMap) }) // len==0 early return
+	benchCase(b, "noMatch", func() { sinkStr = rx.Replace(bnRepEmailRe, bnRepNoMatchIn, bnRepDomainMap) })         // no matches early return
+	benchCase(b, "groupsNotInMap", func() { sinkStr = rx.Replace(bnRepEmailRe, bnRepSingleIn, bnRepMissMap) })     // matches, but 0 spans appended
+	// pathological — overlap (outermost wins) and optional non-participating group.
+	benchCase(b, "nestedGroups", func() { sinkStr = rx.Replace(bnRepNestRe, bnRepSingleIn, bnRepNestMap) })
+	benchCase(b, "optionalNonParticipating", func() { sinkStr = rx.Replace(bnRepOptRe, bnRepOptIn, bnRepOptMap) }) // bang group index -1 skip
+	// scaling — sort size per match, match count, and replacement length.
+	benchCase(b, "manyGroupsPerMatch", func() { sinkStr = rx.Replace(bnRepManyGRe, bnRepManyGIn, bnRepManyGMap) }) // sort.Slice(8)
+	benchCase(b, "largeManyMatches", func() { sinkStr = rx.Replace(bnRepEmailRe, bnRepMulti1200In, bnRepDomainMap) })
+	benchCase(b, "longReplacement", func() { sinkStr = rx.Replace(bnRepEmailRe, bnRepMulti100In, bnRepLongMap) }) // Builder growth
+}
+
+// ── Validate ──────────────────────────────────────────────────────────────────
+//
+// Cost model: build a set of declared names from SubexpNames (scales with
+// declared group count), then look up each required name; misses append to a
+// list joined into the error message. Best case (all present) skips the
+// allocation of the missing list and the strings.Join.
+//
+// The variadic required names are passed as pre-built package-level slices via
+// `slice...` so the backing array is not allocated inside the loop (which would
+// otherwise be wrongly attributed to Validate).
+
+var (
+	bnValRe          = regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
+	bnValPresent     = []string{"name", "age"}
+	bnValPartial     = []string{"name", "missing"}
+	bnValManyRe      = regexp.MustCompile(bnGroupsPattern(20))
+	bnValManyPresent = bnNames("f", 20) // f0..f19 — all declared on bnValManyRe
+	bnValManyMissing = bnNames("m", 20) // m0..m19 — none declared
+	bnValEmptyRe     = regexp.MustCompile(`\w+ \w+`)
+	bnValSome        = []string{"a", "b", "c"}
+	bnValNone        = []string{}
+)
+
+func BenchmarkValidate(b *testing.B) {
+	benchCase(b, "allPresentSmall", func() { sinkErr = rx.Validate(bnValRe, bnValPresent...) })     // nil, no missing-list alloc
+	benchCase(b, "partialMissSmall", func() { sinkErr = rx.Validate(bnValRe, bnValPartial...) })    // 1 missing
+	benchCase(b, "allPresentMany", func() { sinkErr = rx.Validate(bnValManyRe, bnValManyPresent...) }) // 20-name set build + 20 hits
+	benchCase(b, "allMissingMany", func() { sinkErr = rx.Validate(bnValManyRe, bnValManyMissing...) }) // 20 misses + big Join
+	benchCase(b, "noDeclaredSomeRequired", func() { sinkErr = rx.Validate(bnValEmptyRe, bnValSome...) })
+	benchCase(b, "zeroEverything", func() { sinkErr = rx.Validate(bnValEmptyRe, bnValNone...) }) // fixed overhead floor
+}

--- a/bench_sanity_test.go
+++ b/bench_sanity_test.go
@@ -1,0 +1,132 @@
+package regextra_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	rx "github.com/jecoms/regextra"
+)
+
+// TestBenchmarkFixturesSane asserts that the benchmark fixtures actually
+// exercise the paths their names claim. Without this, a fixture that silently
+// stopped matching (a typo'd pattern, a changed input) would make its benchmark
+// quietly measure the no-match path instead — a misleading regression-free
+// "win". This test fails loudly if a representative fixture drifts.
+func TestBenchmarkFixturesSane(t *testing.T) {
+	// FindNamed: match, undeclared group, and no-match shapes.
+	if v, ok := rx.FindNamed(bnFindRe, bnFindInput, "name"); !ok || v != "Alice" {
+		t.Errorf("FindNamed small = (%q,%v), want (Alice,true)", v, ok)
+	}
+	if v, ok := rx.FindNamed(bnFindRe, bnFindInput, "missing"); ok || v != "" {
+		t.Errorf("FindNamed undeclaredGroup = (%q,%v), want (\"\",false)", v, ok)
+	}
+	if _, ok := rx.FindNamed(bnFindEmailRe, bnFindNoMatch, "word"); ok {
+		t.Error("FindNamed noMatch fixture unexpectedly matched")
+	}
+	if v, ok := rx.FindNamed(bnFindManyRe, bnFindManyIn, "j"); !ok || v != "ten" {
+		t.Errorf("FindNamed manyGroupsExtractOne = (%q,%v), want (ten,true)", v, ok)
+	}
+	if v, ok := rx.FindNamed(bnFindEndRe, bnFindEndIn, "value"); !ok || v != "final" {
+		t.Errorf("FindNamed largeMatchAtEnd = (%q,%v), want (final,true)", v, ok)
+	}
+
+	// FindAllNamed: nil (undeclared) vs empty (no match) vs match-count scaling.
+	if got := rx.FindAllNamed(bnFAllRe, bnFAll10, "missing"); got != nil {
+		t.Errorf("FindAllNamed undeclaredGroup = %v, want nil", got)
+	}
+	if got := rx.FindAllNamed(bnFAllRe, "", "word"); got == nil || len(got) != 0 {
+		t.Errorf("FindAllNamed noMatch = %v, want empty non-nil", got)
+	}
+	for _, tc := range []struct {
+		in   string
+		want int
+	}{{bnFAll1, 1}, {bnFAll10, 10}, {bnFAll100, 100}, {bnFAll1000, 1000}, {bnFAll10000, 10000}} {
+		if got := len(rx.FindAllNamed(bnFAllRe, tc.in, "word")); got != tc.want {
+			t.Errorf("FindAllNamed match count = %d, want %d", got, tc.want)
+		}
+	}
+
+	// NamedGroups / AllNamedGroups: populated, no-match, and duplicate-name shapes.
+	if m := rx.NamedGroups(bnNGRe, bnNGIn); len(m) != 2 {
+		t.Errorf("NamedGroups twoGroups size = %d, want 2", len(m))
+	}
+	if m := rx.NamedGroups(bnNGRe, bnNGNoMatch); m == nil || len(m) != 0 {
+		t.Errorf("NamedGroups noMatch = %v, want empty non-nil", m)
+	}
+	if m := rx.NamedGroups(bnNGManyRe, bnNGManyIn); len(m) != 20 {
+		t.Errorf("NamedGroups manyGroups size = %d, want 20", len(m))
+	}
+	if m := rx.AllNamedGroups(bnANGDupRe, bnANGDupIn); len(m["word"]) != 3 {
+		t.Errorf("AllNamedGroups duplicateGroupName word count = %d, want 3", len(m["word"]))
+	}
+	if m := rx.AllNamedGroups(bnANGManyDupRe, bnANGManyDupIn); len(m["w"]) != 20 {
+		t.Errorf("AllNamedGroups manyDuplicates w count = %d, want 20", len(m["w"]))
+	}
+
+	// Replace: substitution count and the two early-return passthroughs.
+	if got := rx.Replace(bnRepEmailRe, bnRepMulti100In, bnRepDomainMap); strings.Count(got, "redacted") != 100 {
+		t.Errorf("Replace matches100 substitutions = %d, want 100", strings.Count(got, "redacted"))
+	}
+	if got := rx.Replace(bnRepEmailRe, bnRepSingleIn, bnRepEmptyMap); got != bnRepSingleIn {
+		t.Errorf("Replace emptyReplacements changed target: %q", got)
+	}
+	if got := rx.Replace(bnRepEmailRe, bnRepNoMatchIn, bnRepDomainMap); got != bnRepNoMatchIn {
+		t.Errorf("Replace noMatch changed target: %q", got)
+	}
+
+	// Validate: present vs missing.
+	if err := rx.Validate(bnValRe, bnValPresent...); err != nil {
+		t.Errorf("Validate allPresentSmall = %v, want nil", err)
+	}
+	if err := rx.Validate(bnValManyRe, bnValManyMissing...); err == nil {
+		t.Error("Validate allMissingMany = nil, want error")
+	}
+
+	// Unmarshal: a real decode, the no-match no-op, and the error path.
+	var s benchSimple
+	if err := rx.Unmarshal(benchSimpleRe, benchSimpleInput, &s); err != nil {
+		t.Fatalf("Unmarshal simpleThreeField error: %v", err)
+	}
+	if s.Name != "Alice" || s.Age != 30 || !s.Active {
+		t.Errorf("Unmarshal simpleThreeField = %+v, want {Alice 30 true}", s)
+	}
+	var s2 benchSimple
+	if err := rx.Unmarshal(benchSimpleRe, benchNoMatchInput, &s2); err != nil || s2 != (benchSimple{}) {
+		t.Errorf("Unmarshal noMatch = (%v, %+v), want (nil, zero)", err, s2)
+	}
+	var bad benchBadInt
+	if err := rx.Unmarshal(benchBadIntRe, benchBadIntIn, &bad); err == nil {
+		t.Error("Unmarshal invalidIntConversion = nil, want error")
+	}
+	var tm benchTime
+	if err := rx.Unmarshal(benchTimeRe, benchTimeLastIn, &tm); err != nil || tm.TS.IsZero() {
+		t.Errorf("Unmarshal timeLastLayout = (%v, %v), want (nil, non-zero time)", err, tm.TS)
+	}
+
+	// UnmarshalAll / Decoder: aligned 100-match corpus and the streaming count.
+	if n := strings.Count(benchBatch100Input, "Alice"); n != 100 {
+		t.Fatalf("benchBatch100Input has %d Alice tokens, want 100", n)
+	}
+	var dst []benchSimple
+	if err := rx.UnmarshalAll(benchSimpleRe, benchBatch100Input, &dst); err != nil || len(dst) != 100 {
+		t.Errorf("UnmarshalAll matches100 = (%v, len %d), want (nil, 100)", err, len(dst))
+	}
+	if _, err := benchSimpleDecoder.One(benchNoMatchInput); !errors.Is(err, rx.ErrNoMatch) {
+		t.Errorf("DecoderOne noMatch err = %v, want ErrNoMatch", err)
+	}
+	all, err := benchSimpleDecoder.All(benchBatch100Input)
+	if err != nil || len(all) != 100 {
+		t.Errorf("DecoderAll matches100 = (%v, len %d), want (nil, 100)", err, len(all))
+	}
+	n := 0
+	for _, err := range benchLogDecoder.Iter(benchLogIn) {
+		if err != nil {
+			t.Fatalf("DecoderIter error: %v", err)
+		}
+		n++
+	}
+	if n != 100 {
+		t.Errorf("DecoderIter fullIteration count = %d, want 100", n)
+	}
+}

--- a/bench_sanity_test.go
+++ b/bench_sanity_test.go
@@ -13,8 +13,22 @@ import (
 // stopped matching (a typo'd pattern, a changed input) would make its benchmark
 // quietly measure the no-match path instead — a misleading regression-free
 // "win". This test fails loudly if a representative fixture drifts.
+//
+// The checks are grouped into one subtest per exported function so a drift is
+// attributed to the right surface (and so no single function trips the gocyclo
+// limit).
 func TestBenchmarkFixturesSane(t *testing.T) {
-	// FindNamed: match, undeclared group, and no-match shapes.
+	t.Run("FindNamed", checkFindNamedFixtures)
+	t.Run("FindAllNamed", checkFindAllNamedFixtures)
+	t.Run("NamedGroups", checkNamedGroupsFixtures)
+	t.Run("Replace", checkReplaceFixtures)
+	t.Run("Validate", checkValidateFixtures)
+	t.Run("Unmarshal", checkUnmarshalFixtures)
+	t.Run("UnmarshalAll/Decoder", checkDecoderFixtures)
+}
+
+// FindNamed: match, undeclared group, and no-match shapes.
+func checkFindNamedFixtures(t *testing.T) {
 	if v, ok := rx.FindNamed(bnFindRe, bnFindInput, "name"); !ok || v != "Alice" {
 		t.Errorf("FindNamed small = (%q,%v), want (Alice,true)", v, ok)
 	}
@@ -30,8 +44,10 @@ func TestBenchmarkFixturesSane(t *testing.T) {
 	if v, ok := rx.FindNamed(bnFindEndRe, bnFindEndIn, "value"); !ok || v != "final" {
 		t.Errorf("FindNamed largeMatchAtEnd = (%q,%v), want (final,true)", v, ok)
 	}
+}
 
-	// FindAllNamed: nil (undeclared) vs empty (no match) vs match-count scaling.
+// FindAllNamed: nil (undeclared) vs empty (no match) vs match-count scaling.
+func checkFindAllNamedFixtures(t *testing.T) {
 	if got := rx.FindAllNamed(bnFAllRe, bnFAll10, "missing"); got != nil {
 		t.Errorf("FindAllNamed undeclaredGroup = %v, want nil", got)
 	}
@@ -46,8 +62,10 @@ func TestBenchmarkFixturesSane(t *testing.T) {
 			t.Errorf("FindAllNamed match count = %d, want %d", got, tc.want)
 		}
 	}
+}
 
-	// NamedGroups / AllNamedGroups: populated, no-match, and duplicate-name shapes.
+// NamedGroups / AllNamedGroups: populated, no-match, and duplicate-name shapes.
+func checkNamedGroupsFixtures(t *testing.T) {
 	if m := rx.NamedGroups(bnNGRe, bnNGIn); len(m) != 2 {
 		t.Errorf("NamedGroups twoGroups size = %d, want 2", len(m))
 	}
@@ -63,8 +81,10 @@ func TestBenchmarkFixturesSane(t *testing.T) {
 	if m := rx.AllNamedGroups(bnANGManyDupRe, bnANGManyDupIn); len(m["w"]) != 20 {
 		t.Errorf("AllNamedGroups manyDuplicates w count = %d, want 20", len(m["w"]))
 	}
+}
 
-	// Replace: substitution count and the two early-return passthroughs.
+// Replace: substitution count and the two early-return passthroughs.
+func checkReplaceFixtures(t *testing.T) {
 	if got := rx.Replace(bnRepEmailRe, bnRepMulti100In, bnRepDomainMap); strings.Count(got, "redacted") != 100 {
 		t.Errorf("Replace matches100 substitutions = %d, want 100", strings.Count(got, "redacted"))
 	}
@@ -74,16 +94,20 @@ func TestBenchmarkFixturesSane(t *testing.T) {
 	if got := rx.Replace(bnRepEmailRe, bnRepNoMatchIn, bnRepDomainMap); got != bnRepNoMatchIn {
 		t.Errorf("Replace noMatch changed target: %q", got)
 	}
+}
 
-	// Validate: present vs missing.
+// Validate: present vs missing.
+func checkValidateFixtures(t *testing.T) {
 	if err := rx.Validate(bnValRe, bnValPresent...); err != nil {
 		t.Errorf("Validate allPresentSmall = %v, want nil", err)
 	}
 	if err := rx.Validate(bnValManyRe, bnValManyMissing...); err == nil {
 		t.Error("Validate allMissingMany = nil, want error")
 	}
+}
 
-	// Unmarshal: a real decode, the no-match no-op, and the error path.
+// Unmarshal: a real decode, the no-match no-op, and the error path.
+func checkUnmarshalFixtures(t *testing.T) {
 	var s benchSimple
 	if err := rx.Unmarshal(benchSimpleRe, benchSimpleInput, &s); err != nil {
 		t.Fatalf("Unmarshal simpleThreeField error: %v", err)
@@ -103,8 +127,10 @@ func TestBenchmarkFixturesSane(t *testing.T) {
 	if err := rx.Unmarshal(benchTimeRe, benchTimeLastIn, &tm); err != nil || tm.TS.IsZero() {
 		t.Errorf("Unmarshal timeLastLayout = (%v, %v), want (nil, non-zero time)", err, tm.TS)
 	}
+}
 
-	// UnmarshalAll / Decoder: aligned 100-match corpus and the streaming count.
+// UnmarshalAll / Decoder: aligned 100-match corpus and the streaming count.
+func checkDecoderFixtures(t *testing.T) {
 	if n := strings.Count(benchBatch100Input, "Alice"); n != 100 {
 		t.Fatalf("benchBatch100Input has %d Alice tokens, want 100", n)
 	}

--- a/bench_test.go
+++ b/bench_test.go
@@ -117,26 +117,26 @@ func bnNames(prefix string, n int) []string {
 // pattern stresses NFA simulation, it does not blow up.
 
 var (
-	bnFindRe       = regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
-	bnFindInput    = "Alice is 30"
-	bnFindEmailRe  = regexp.MustCompile(`(?P<word>\w+)@(?P<domain>\w+)`)
-	bnFindNoMatch  = "not-an-email-just-text"
-	bnFindZeroRe   = regexp.MustCompile(`(?P<prefix>\w*)@(?P<domain>\w+)`)
-	bnFindZeroIn   = "@example.com"
-	bnFindMedRe    = regexp.MustCompile(`(?P<tag>[a-z]+):\s*(?P<value>[^;]+)`)
-	bnFindMedIn    = strings.Repeat("x:y;", 50) + "target:extracted"
-	bnFindStartRe  = regexp.MustCompile(`^(?P<header>\w+):`)
-	bnFindStartIn  = "START:" + strings.Repeat("x", 5000)
-	bnFindEndRe    = regexp.MustCompile(`(?P<value>\w+)$`)
-	bnFindEndIn    = strings.Repeat("x", 5000) + " final"
-	bnFindManyRe   = regexp.MustCompile(`(?P<a>\w+) (?P<b>\w+) (?P<c>\w+) (?P<d>\w+) (?P<e>\w+) (?P<f>\w+) (?P<g>\w+) (?P<h>\w+) (?P<i>\w+) (?P<j>\w+)`)
-	bnFindManyIn   = "one two three four five six seven eight nine ten"
-	bnFindUTF8Re   = regexp.MustCompile(`(?P<name>\p{L}+) (\p{L}+) (?P<age>\d+)`)
-	bnFindUTF8In   = "María José 28" + strings.Repeat(" 日本語", 10)
-	bnFindAnchRe   = regexp.MustCompile(`^(?P<method>GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) (?P<path>/[^\s]+)$`)
-	bnFindAnchIn   = "POST /api/users/123"
-	bnFindNestRe   = regexp.MustCompile(`(?P<value>a+)+b`)
-	bnFindNestIn   = strings.Repeat("a", 25) + "c"
+	bnFindRe      = regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
+	bnFindInput   = "Alice is 30"
+	bnFindEmailRe = regexp.MustCompile(`(?P<word>\w+)@(?P<domain>\w+)`)
+	bnFindNoMatch = "not-an-email-just-text"
+	bnFindZeroRe  = regexp.MustCompile(`(?P<prefix>\w*)@(?P<domain>\w+)`)
+	bnFindZeroIn  = "@example.com"
+	bnFindMedRe   = regexp.MustCompile(`(?P<tag>[a-z]+):\s*(?P<value>[^;]+)`)
+	bnFindMedIn   = strings.Repeat("x:y;", 50) + "target:extracted"
+	bnFindStartRe = regexp.MustCompile(`^(?P<header>\w+):`)
+	bnFindStartIn = "START:" + strings.Repeat("x", 5000)
+	bnFindEndRe   = regexp.MustCompile(`(?P<value>\w+)$`)
+	bnFindEndIn   = strings.Repeat("x", 5000) + " final"
+	bnFindManyRe  = regexp.MustCompile(`(?P<a>\w+) (?P<b>\w+) (?P<c>\w+) (?P<d>\w+) (?P<e>\w+) (?P<f>\w+) (?P<g>\w+) (?P<h>\w+) (?P<i>\w+) (?P<j>\w+)`)
+	bnFindManyIn  = "one two three four five six seven eight nine ten"
+	bnFindUTF8Re  = regexp.MustCompile(`(?P<name>\p{L}+) (\p{L}+) (?P<age>\d+)`)
+	bnFindUTF8In  = "María José 28" + strings.Repeat(" 日本語", 10)
+	bnFindAnchRe  = regexp.MustCompile(`^(?P<method>GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) (?P<path>/[^\s]+)$`)
+	bnFindAnchIn  = "POST /api/users/123"
+	bnFindNestRe  = regexp.MustCompile(`(?P<value>a+)+b`)
+	bnFindNestIn  = strings.Repeat("a", 25) + "c"
 )
 
 func BenchmarkFindNamed(b *testing.B) {
@@ -207,8 +207,8 @@ var (
 )
 
 func BenchmarkNamedGroups(b *testing.B) {
-	benchCase(b, "twoGroups", func() { sinkMap = rx.NamedGroups(bnNGRe, bnNGIn) })        // representative
-	benchCase(b, "noMatch", func() { sinkMap = rx.NamedGroups(bnNGRe, bnNGNoMatch) })     // empty non-nil map, pre-loop return
+	benchCase(b, "twoGroups", func() { sinkMap = rx.NamedGroups(bnNGRe, bnNGIn) })          // representative
+	benchCase(b, "noMatch", func() { sinkMap = rx.NamedGroups(bnNGRe, bnNGNoMatch) })       // empty non-nil map, pre-loop return
 	benchCase(b, "manyGroups", func() { sinkMap = rx.NamedGroups(bnNGManyRe, bnNGManyIn) }) // map-insertion scaling (20 groups)
 }
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,281 +1,237 @@
 package regextra_test
 
-import (
-	rx "github.com/jecoms/regextra"
-	"regexp"
-	"strings"
-	"testing"
-	"time"
-)
-
-// Benchmarks for the hot paths users actually call. The goal is twofold:
+// Benchmark suite for regextra's exported surface.
 //
-//  1. Establish a baseline against which v0.5.0's Decoder[T] (re-3e2) can
-//     demonstrate its caching win.
-//  2. Catch regressions on the existing free-function path. v0.4.0 added four
-//     dispatch checks at the top of setFieldValue (pointer, RegexUnmarshaler,
-//     time.Time, time.Duration) — keep the absolute cost visible so future
-//     additions are vetted against a budget rather than guessed about.
+// Goals (see the package doc's "Performance" section for the user-facing claims
+// these numbers back):
+//
+//  1. Give every exported function a STATISTICALLY REPRESENTATIVE sample of
+//     real-world inputs — a small/medium/large progression spanning the
+//     realistic distribution of input size and match/group count — not one
+//     arbitrary fixture.
+//  2. Cover the edge and pathological corners of each cost model: the no-match
+//     shapes from the package's no-match contract table, optional/empty groups,
+//     duplicate group names, unicode, the time-layout best/worst pair, every
+//     setFieldValue dispatch branch, and the argument-validation guards.
+//  3. Keep head-to-head pairs (Unmarshal vs Decoder.One, UnmarshalAll vs
+//     Decoder.All) on BYTE-IDENTICAL regex + struct + input so benchstat can
+//     diff the caching win directly.
+//
+// Conventions:
+//   - One top-level Benchmark<Func> per exported function; cases are flat
+//     lowerCamelCase b.Run sub-names drawn from a shared vocabulary
+//     (noMatch, undeclaredGroup, singleMatch, small/medium/large, matchesN,
+//     fieldsN, groupsN, firstLayout/lastLayout).
+//   - Every fixture is a package-level var/const named bn<Group><Case>* —
+//     nothing built with strings.Repeat/Join/Sprintf or a variadic literal is
+//     constructed inside a benchmark loop, so the harness measures the function
+//     under test, not fixture construction.
+//   - Every loop body assigns its result to a typed package-level sink so the
+//     optimizer cannot fold the call to a no-op store (belt-and-suspenders on
+//     top of Go 1.24's b.Loop, which already keeps the call alive).
 //
 // Run with:
 //
 //	go test -bench=. -benchmem -run=^$ ./...
-
-// ── Find / NamedGroups baseline ───────────────────────────────────────────────
-
-var benchFindRe = regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
-
-// BenchmarkFindNamed measures the single-group, single-match extraction path —
-// the cheapest function in the package and the baseline for everything else.
-func BenchmarkFindNamed(b *testing.B) {
-	b.ReportAllocs()
-	for b.Loop() {
-		_, _ = rx.FindNamed(benchFindRe, "Alice is 30", "name")
-	}
-}
-
-// BenchmarkNamedGroups measures the all-groups-as-map path. The map allocation
-// dominates the cost vs. FindNamed.
-func BenchmarkNamedGroups(b *testing.B) {
-	b.ReportAllocs()
-	for b.Loop() {
-		_ = rx.NamedGroups(benchFindRe, "Alice is 30")
-	}
-}
-
-// BenchmarkFindAllNamed measures the all-matches projection of one named group.
-// Allocation scales with match count.
-func BenchmarkFindAllNamed(b *testing.B) {
-	re := regexp.MustCompile(`(?P<word>\S+)`)
-	target := "alpha beta gamma delta epsilon zeta eta theta"
-	b.ReportAllocs()
-	for b.Loop() {
-		_ = rx.FindAllNamed(re, target, "word")
-	}
-}
-
-// ── Replace ───────────────────────────────────────────────────────────────────
-
-// BenchmarkReplace measures the substitution path: scan all matches, sort
-// per-match group spans, build the output string. Three matches in the input
-// to exercise the multi-match branch.
-func BenchmarkReplace(b *testing.B) {
-	re := regexp.MustCompile(`(?P<user>\w+)@(?P<domain>[\w.]+)`)
-	target := "alice@example.com bob@other.org carol@third.net"
-	repl := map[string]string{"domain": "redacted"}
-	b.ReportAllocs()
-	for b.Loop() {
-		_ = rx.Replace(re, target, repl)
-	}
-}
-
-// ── Unmarshal: simple struct (string + int + bool) ───────────────────────────
 //
-// Baseline for the most common shape. Hits the kind switch path with no
-// pointer / RegexUnmarshaler / time.Time fast-paths — measures the cost of
-// the four dispatch checks added in v0.4.0 against a "boring" struct.
-
-// benchSimple is a 3-field destination struct using only the kind-switch
-// branches of setFieldValue: string, int, bool. The benchmark measures that
-// path's per-call cost.
-type benchSimple struct {
-	Name   string `regex:"name"`
-	Age    int    `regex:"age"`
-	Active bool   `regex:"active"`
-}
-
-var benchSimpleRe = regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+) (?P<active>\w+)`)
-
-// BenchmarkUnmarshal_simpleStruct measures the kind-switch path with no fast
-// paths hit. Establishes the baseline that Decoder[T] should beat.
-func BenchmarkUnmarshal_simpleStruct(b *testing.B) {
-	target := "Alice is 30 true"
-	b.ReportAllocs()
-	for b.Loop() {
-		var s benchSimple
-		if err := rx.Unmarshal(benchSimpleRe, target, &s); err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-// benchSimpleDecoder is the same struct decoded via a precompiled Decoder.
-// Compare against BenchmarkUnmarshal_simpleStruct to see the v0.5.0 win.
-var benchSimpleDecoder = rx.MustCompile[benchSimple](`(?P<name>\w+) is (?P<age>\d+) (?P<active>\w+)`)
-
-// BenchmarkDecoder_simpleStruct.One measures the same shape as
-// BenchmarkUnmarshal_simpleStruct via a precompiled Decoder. Both reuse
-// setFieldValue, but the Decoder skips the per-call SubexpNames loop and
-// per-field parseFieldTag work — that's where the win comes from.
-func BenchmarkDecoder_simpleStruct(b *testing.B) {
-	target := "Alice is 30 true"
-	b.ReportAllocs()
-	for b.Loop() {
-		_, err := benchSimpleDecoder.One(target)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-// ── Unmarshal: pointer fields ────────────────────────────────────────────────
+// A/B a single function across a change with:
 //
-// Exercises the new pointer-dispatch step (allocate-if-nil + recurse). Cost
-// per field: one Kind() check + one IsNil() check + one allocation per nil
-// pointer.
+//	go test -bench=BenchmarkUnmarshal -benchmem -run=^$ -count=10 ./... | tee new.txt
+//	benchstat old.txt new.txt
 
-// benchPointers exercises the pointer dispatch step (allocate-if-nil + recurse).
-type benchPointers struct {
-	Name *string `regex:"name"`
-	Age  *int    `regex:"age"`
-}
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
 
-// BenchmarkUnmarshal_pointerFields measures the cost of the pointer dispatch
-// step plus the per-field allocation that nil pointers incur.
-func BenchmarkUnmarshal_pointerFields(b *testing.B) {
-	target := "Alice is 30"
-	re := regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
-	b.ReportAllocs()
-	for b.Loop() {
-		var p benchPointers
-		if err := rx.Unmarshal(re, target, &p); err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-// ── Unmarshal: time.Time + time.Duration ─────────────────────────────────────
-//
-// Hits the time-types fast path (Type-equality match before the Kind switch).
-// The fallback time.Parse loop runs only on first-layout-miss; this benchmark
-// uses RFC3339 input so the first layout matches.
-
-// benchTime exercises the time-types fast paths (Type-equality match before
-// the kind switch).
-type benchTime struct {
-	TS   time.Time     `regex:"ts"`
-	Took time.Duration `regex:"took"`
-}
-
-var benchTimeRe = regexp.MustCompile(`(?P<ts>\S+) \((?P<took>\S+)\)`)
-
-// BenchmarkUnmarshal_timeFields measures the time.Time + time.Duration fast
-// paths. Input is RFC3339 so the first layout in the fallback list matches —
-// worst-case (last-layout-wins) is not measured here.
-func BenchmarkUnmarshal_timeFields(b *testing.B) {
-	target := "2026-04-26T12:34:56Z (1h30m)"
-	b.ReportAllocs()
-	for b.Loop() {
-		var t benchTime
-		if err := rx.Unmarshal(benchTimeRe, target, &t); err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-// ── Unmarshal: RegexUnmarshaler-implementing field ───────────────────────────
-//
-// Exercises the interface-dispatch step. The test type is intentionally simple
-// so the benchmark measures dispatch cost, not the body of UnmarshalRegex.
-
-// benchStatus is a caller-defined enum whose pointer satisfies
-// RegexUnmarshaler. Used to measure the interface-dispatch step.
-type benchStatus int
-
-const (
-	benchStatusUnknown benchStatus = iota
-	benchStatusOpen
-	benchStatusClosed
+	rx "github.com/jecoms/regextra"
 )
 
-// UnmarshalRegex maps the matched string to a benchStatus value. Body kept
-// minimal so the benchmark measures dispatch cost, not parse cost.
-func (s *benchStatus) UnmarshalRegex(value string) error {
-	switch value {
-	case "open":
-		*s = benchStatusOpen
-	case "closed":
-		*s = benchStatusClosed
-	default:
-		*s = benchStatusUnknown
-	}
-	return nil
-}
+// ── Typed sinks ───────────────────────────────────────────────────────────────
+// One per return kind, assigned in every loop body to defeat dead-store
+// elimination of the benchmarked call's result.
+var (
+	sinkStr   string
+	sinkOK    bool
+	sinkStrs  []string
+	sinkMap   map[string]string
+	sinkMapSS map[string][]string
+	sinkErr   error
+	sinkAny   any
+)
 
-// benchCustom is the destination struct for the RegexUnmarshaler benchmark.
-type benchCustom struct {
-	State benchStatus `regex:"state"`
-}
-
-var benchCustomRe = regexp.MustCompile(`\[(?P<state>\w+)\]`)
-
-// BenchmarkUnmarshal_customUnmarshaler measures the RegexUnmarshaler interface
-// dispatch step in setFieldValue. The custom UnmarshalRegex body is trivial so
-// the timing reflects dispatch overhead rather than user-defined work.
-func BenchmarkUnmarshal_customUnmarshaler(b *testing.B) {
-	target := "[open]"
-	b.ReportAllocs()
-	for b.Loop() {
-		var c benchCustom
-		if err := rx.Unmarshal(benchCustomRe, target, &c); err != nil {
-			b.Fatal(err)
+// benchCase runs fn in an allocation-reporting b.Loop under a named sub-benchmark.
+// fn must assign the result of the call under test to a sink. The single indirect
+// call benchCase adds is a constant offset across every case (and mirrors how real
+// callers invoke these funcs — through a call boundary, not inlined), so it leaves
+// relative comparisons and benchstat diffs valid.
+func benchCase(b *testing.B, name string, fn func()) {
+	b.Helper()
+	b.Run(name, func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			fn()
 		}
-	}
+	})
 }
 
-// ── UnmarshalAll: 100 log-line iteration ─────────────────────────────────────
+// ── Shared fixture generators (run at package init, never in a loop) ──────────
+
+// bnGroupsPattern builds a pattern of n distinct named groups f0..f(n-1)
+// separated by spaces, e.g. `(?P<f0>\w+) (?P<f1>\w+)`.
+func bnGroupsPattern(n int) string {
+	parts := make([]string, n)
+	for i := range parts {
+		parts[i] = fmt.Sprintf(`(?P<f%d>\w+)`, i)
+	}
+	return strings.Join(parts, " ")
+}
+
+// bnWords builds n space-separated "w" tokens, the matching input for
+// bnGroupsPattern(n).
+func bnWords(n int) string {
+	parts := make([]string, n)
+	for i := range parts {
+		parts[i] = "w"
+	}
+	return strings.Join(parts, " ")
+}
+
+// bnNames builds n names prefix0..prefix(n-1), used to pre-build the variadic
+// slice for Validate so the backing array is not allocated inside the loop.
+func bnNames(prefix string, n int) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = fmt.Sprintf("%s%d", prefix, i)
+	}
+	return out
+}
+
+// ── FindNamed ─────────────────────────────────────────────────────────────────
 //
-// The realistic hot path for log parsers. Measures per-line amortized cost
-// across a batch — the metric Decoder[T] (re-3e2) is designed to improve.
+// Cost model: SubexpIndex (O(declared groups), returns -1 on an undeclared name
+// before any matching) then FindStringSubmatch, which dominates — it runs the
+// RE2 NFA simulation over the target and allocates the capture slice. Go's
+// regexp is RE2: linear time, no backtracking, no ReDoS — so a "pathological"
+// pattern stresses NFA simulation, it does not blow up.
 
-// BenchmarkUnmarshalAll_logLines measures amortized per-line decode cost
-// across a 100-line batch. This is the hot path Decoder[T] (re-3e2) is
-// designed to optimize — each iteration today rebuilds the reflect plan
-// from scratch.
-func BenchmarkUnmarshalAll_logLines(b *testing.B) {
-	type line struct {
-		Level string `regex:"level"`
-		Msg   string `regex:"msg"`
-	}
-	re := regexp.MustCompile(`\[(?P<level>\w+)\] (?P<msg>[^\n]+)`)
-	// 100 lines of input
-	target := strings.Repeat("[info] message body here\n", 100)
-	b.ReportAllocs()
-	for b.Loop() {
-		var lines []line
-		if err := rx.UnmarshalAll(re, target, &lines); err != nil {
-			b.Fatal(err)
-		}
-	}
+var (
+	bnFindRe       = regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
+	bnFindInput    = "Alice is 30"
+	bnFindEmailRe  = regexp.MustCompile(`(?P<word>\w+)@(?P<domain>\w+)`)
+	bnFindNoMatch  = "not-an-email-just-text"
+	bnFindZeroRe   = regexp.MustCompile(`(?P<prefix>\w*)@(?P<domain>\w+)`)
+	bnFindZeroIn   = "@example.com"
+	bnFindMedRe    = regexp.MustCompile(`(?P<tag>[a-z]+):\s*(?P<value>[^;]+)`)
+	bnFindMedIn    = strings.Repeat("x:y;", 50) + "target:extracted"
+	bnFindStartRe  = regexp.MustCompile(`^(?P<header>\w+):`)
+	bnFindStartIn  = "START:" + strings.Repeat("x", 5000)
+	bnFindEndRe    = regexp.MustCompile(`(?P<value>\w+)$`)
+	bnFindEndIn    = strings.Repeat("x", 5000) + " final"
+	bnFindManyRe   = regexp.MustCompile(`(?P<a>\w+) (?P<b>\w+) (?P<c>\w+) (?P<d>\w+) (?P<e>\w+) (?P<f>\w+) (?P<g>\w+) (?P<h>\w+) (?P<i>\w+) (?P<j>\w+)`)
+	bnFindManyIn   = "one two three four five six seven eight nine ten"
+	bnFindUTF8Re   = regexp.MustCompile(`(?P<name>\p{L}+) (\p{L}+) (?P<age>\d+)`)
+	bnFindUTF8In   = "María José 28" + strings.Repeat(" 日本語", 10)
+	bnFindAnchRe   = regexp.MustCompile(`^(?P<method>GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) (?P<path>/[^\s]+)$`)
+	bnFindAnchIn   = "POST /api/users/123"
+	bnFindNestRe   = regexp.MustCompile(`(?P<value>a+)+b`)
+	bnFindNestIn   = strings.Repeat("a", 25) + "c"
+)
+
+func BenchmarkFindNamed(b *testing.B) {
+	// representative — the common one-shot extraction fast path.
+	benchCase(b, "small", func() { sinkStr, sinkOK = rx.FindNamed(bnFindRe, bnFindInput, "name") })
+	benchCase(b, "medium", func() { sinkStr, sinkOK = rx.FindNamed(bnFindMedRe, bnFindMedIn, "tag") })
+	benchCase(b, "multibyteUTF8", func() { sinkStr, sinkOK = rx.FindNamed(bnFindUTF8Re, bnFindUTF8In, "name") })
+	benchCase(b, "anchored", func() { sinkStr, sinkOK = rx.FindNamed(bnFindAnchRe, bnFindAnchIn, "method") })
+	// edge — no-match contract shapes and group boundaries.
+	benchCase(b, "undeclaredGroup", func() { sinkStr, sinkOK = rx.FindNamed(bnFindRe, bnFindInput, "missing") }) // SubexpIndex == -1, no scan
+	benchCase(b, "noMatch", func() { sinkStr, sinkOK = rx.FindNamed(bnFindEmailRe, bnFindNoMatch, "word") })     // declared group, full no-match scan
+	benchCase(b, "zeroLengthMatch", func() { sinkStr, sinkOK = rx.FindNamed(bnFindZeroRe, bnFindZeroIn, "prefix") })
+	// scaling — capture-slice allocation and scan-length growth.
+	benchCase(b, "manyGroupsExtractOne", func() { sinkStr, sinkOK = rx.FindNamed(bnFindManyRe, bnFindManyIn, "j") }) // 10-element capture slice; SubexpIndex a minor addend
+	benchCase(b, "largeMatchAtStart", func() { sinkStr, sinkOK = rx.FindNamed(bnFindStartRe, bnFindStartIn, "header") })
+	benchCase(b, "largeMatchAtEnd", func() { sinkStr, sinkOK = rx.FindNamed(bnFindEndRe, bnFindEndIn, "value") })
+	// pathological — NFA simulation of a nested quantifier with no match (linear, not catastrophic).
+	benchCase(b, "nestedQuantifierNoMatch", func() { sinkStr, sinkOK = rx.FindNamed(bnFindNestRe, bnFindNestIn, "value") })
 }
 
-// benchIterLine + benchIterDecoder are the Iter-side fixtures, paralleling
-// BenchmarkUnmarshalAll_logLines. Iter doesn't allocate the result slice; the
-// benchmark consumes via a counter to keep the loop body honest.
-type benchIterLine struct {
-	Level string `regex:"level"`
-	Msg   string `regex:"msg"`
+// ── FindAllNamed ──────────────────────────────────────────────────────────────
+//
+// Cost model: FindAllStringSubmatch scans the whole target and allocates a
+// [][]string of every match; FindAllNamed then projects one group into an
+// out []string whose size scales with match count. Undeclared group → nil
+// before any scan; declared-but-no-match → empty slice.
+
+var (
+	bnFAllRe       = regexp.MustCompile(`(?P<word>\S+)`)
+	bnFAll1        = "alpha"
+	bnFAll10       = strings.TrimSpace(strings.Repeat("w ", 10))
+	bnFAll100      = strings.TrimSpace(strings.Repeat("w ", 100))
+	bnFAll1000     = strings.TrimSpace(strings.Repeat("w ", 1000))
+	bnFAll10000    = strings.TrimSpace(strings.Repeat("w ", 10000))
+	bnFAllSparseRe = regexp.MustCompile(`(?P<num>\d+)`)
+	bnFAllSparseIn = strings.Repeat("abcdefghij", 1000) + " 1 2 3" // large target, few matches
+	bnFAllDenseRe  = regexp.MustCompile(`(?P<c>\w)`)
+	bnFAllDenseIn  = strings.Repeat("a", 500) // many tiny matches in a small target
+)
+
+func BenchmarkFindAllNamed(b *testing.B) {
+	// edge — the two no-match shapes (nil vs empty slice).
+	benchCase(b, "undeclaredGroup", func() { sinkStrs = rx.FindAllNamed(bnFAllRe, bnFAll10, "missing") }) // nil path, no scan
+	benchCase(b, "noMatch", func() { sinkStrs = rx.FindAllNamed(bnFAllRe, "", "word") })                  // declared, empty slice
+	// representative + scaling — allocation scales with match count.
+	benchCase(b, "singleMatch", func() { sinkStrs = rx.FindAllNamed(bnFAllRe, bnFAll1, "word") })
+	benchCase(b, "matches10", func() { sinkStrs = rx.FindAllNamed(bnFAllRe, bnFAll10, "word") })
+	benchCase(b, "matches100", func() { sinkStrs = rx.FindAllNamed(bnFAllRe, bnFAll100, "word") })
+	benchCase(b, "matches1000", func() { sinkStrs = rx.FindAllNamed(bnFAllRe, bnFAll1000, "word") })
+	benchCase(b, "matches10000", func() { sinkStrs = rx.FindAllNamed(bnFAllRe, bnFAll10000, "word") })
+	// pathological — target size vs match density.
+	benchCase(b, "sparseLarge", func() { sinkStrs = rx.FindAllNamed(bnFAllSparseRe, bnFAllSparseIn, "num") })
+	benchCase(b, "denseSmall", func() { sinkStrs = rx.FindAllNamed(bnFAllDenseRe, bnFAllDenseIn, "c") })
 }
 
-var benchIterDecoder = rx.MustCompile[benchIterLine](`\[(?P<level>\w+)\] (?P<msg>[^\n]+)`)
+// ── NamedGroups ───────────────────────────────────────────────────────────────
+//
+// Cost model: FindStringSubmatch, then a SubexpNames loop populating a map
+// whose insertion cost scales with declared (named) group count. No-match still
+// allocates the empty (non-nil) map and returns before the loop.
 
-// BenchmarkDecoder_Iter_logLines measures Iter-based streaming decode of the
-// same 100-line corpus as BenchmarkUnmarshalAll_logLines. The win vs.
-// UnmarshalAll comes from skipping the slice allocation — useful when the
-// caller processes-and-discards each item.
-func BenchmarkDecoder_Iter_logLines(b *testing.B) {
-	target := strings.Repeat("[info] message body here\n", 100)
-	b.ReportAllocs()
-	for b.Loop() {
-		count := 0
-		for _, err := range benchIterDecoder.Iter(target) {
-			if err != nil {
-				b.Fatal(err)
-			}
-			count++
-		}
-		if count != 100 {
-			b.Fatalf("got %d lines, want 100", count)
-		}
-	}
+var (
+	bnNGRe      = regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
+	bnNGIn      = "Alice is 30"
+	bnNGNoMatch = "no match here"
+	bnNGManyRe  = regexp.MustCompile(bnGroupsPattern(20))
+	bnNGManyIn  = bnWords(20)
+)
+
+func BenchmarkNamedGroups(b *testing.B) {
+	benchCase(b, "twoGroups", func() { sinkMap = rx.NamedGroups(bnNGRe, bnNGIn) })        // representative
+	benchCase(b, "noMatch", func() { sinkMap = rx.NamedGroups(bnNGRe, bnNGNoMatch) })     // empty non-nil map, pre-loop return
+	benchCase(b, "manyGroups", func() { sinkMap = rx.NamedGroups(bnNGManyRe, bnNGManyIn) }) // map-insertion scaling (20 groups)
+}
+
+// ── AllNamedGroups ────────────────────────────────────────────────────────────
+//
+// Cost model: like NamedGroups, but values are []string, so each distinct group
+// costs an extra one-element slice allocation, and a repeated group name forces
+// slice append/regrowth under one key — the path this function exists for.
+
+var (
+	bnANGDistinctRe = regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
+	bnANGDistinctIn = "Alice 30"
+	bnANGDupRe      = regexp.MustCompile(`(?P<word>\w+) (?P<word>\w+) (?P<word>\w+)`)
+	bnANGDupIn      = "alpha beta gamma"
+	bnANGNoMatch    = "nomatch"
+	bnANGManyDupRe  = regexp.MustCompile(strings.Repeat(`(?P<w>\w+)\s*`, 20))
+	bnANGManyDupIn  = strings.Repeat("x ", 20)
+)
+
+func BenchmarkAllNamedGroups(b *testing.B) {
+	// distinctGroups pairs with NamedGroups/twoGroups-style input to expose the slice-per-key tax.
+	benchCase(b, "distinctGroups", func() { sinkMapSS = rx.AllNamedGroups(bnANGDistinctRe, bnANGDistinctIn) })
+	benchCase(b, "duplicateGroupName", func() { sinkMapSS = rx.AllNamedGroups(bnANGDupRe, bnANGDupIn) }) // 3 occurrences under one key
+	benchCase(b, "noMatch", func() { sinkMapSS = rx.AllNamedGroups(bnANGDistinctRe, bnANGNoMatch) })
+	benchCase(b, "manyDuplicates", func() { sinkMapSS = rx.AllNamedGroups(bnANGManyDupRe, bnANGManyDupIn) }) // 20 appends + regrowth under one key
 }

--- a/bench_unmarshal_test.go
+++ b/bench_unmarshal_test.go
@@ -1,0 +1,319 @@
+package regextra_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	rx "github.com/jecoms/regextra"
+)
+
+// ── Shared decode fixtures ────────────────────────────────────────────────────
+//
+// These types and inputs are shared by the Unmarshal/UnmarshalAll benchmarks
+// here and the Compile/Decoder benchmarks in bench_decoder_test.go. The
+// head-to-head pairs MUST stay byte-identical so benchstat can diff the caching
+// win: Unmarshal/simpleThreeField vs DecoderOne/simple share benchSimple +
+// benchSimplePattern + benchSimpleInput; UnmarshalAll/matches100 vs
+// DecoderAll/matches100 share benchSimple + benchBatch100Input.
+
+// benchSimple — the canonical 3-field destination (string + int + bool).
+type benchSimple struct {
+	Name   string `regex:"name"`
+	Age    int    `regex:"age"`
+	Active bool   `regex:"active"`
+}
+
+const benchSimplePattern = `(?P<name>\w+) is (?P<age>\d+) (?P<active>\w+)`
+
+var (
+	benchSimpleRe    = regexp.MustCompile(benchSimplePattern)
+	benchSimpleInput = "Alice is 30 true"
+	benchSimpleVal   benchSimple // passed by value to hit the non-pointer guard
+
+	// Each "Alice is 30 true and " segment is exactly one match of benchSimpleRe.
+	benchBatch10Input   = strings.Repeat("Alice is 30 true and ", 10)
+	benchBatch100Input  = strings.Repeat("Alice is 30 true and ", 100)
+	benchBatch1000Input = strings.Repeat("Alice is 30 true and ", 1000)
+	benchNoMatchInput   = "no matches here"
+)
+
+// benchWide — a 20-field destination for the per-field overhead sweep.
+type benchWide struct {
+	F0  string `regex:"f0"`
+	F1  string `regex:"f1"`
+	F2  string `regex:"f2"`
+	F3  string `regex:"f3"`
+	F4  string `regex:"f4"`
+	F5  string `regex:"f5"`
+	F6  string `regex:"f6"`
+	F7  string `regex:"f7"`
+	F8  string `regex:"f8"`
+	F9  string `regex:"f9"`
+	F10 string `regex:"f10"`
+	F11 string `regex:"f11"`
+	F12 string `regex:"f12"`
+	F13 string `regex:"f13"`
+	F14 string `regex:"f14"`
+	F15 string `regex:"f15"`
+	F16 string `regex:"f16"`
+	F17 string `regex:"f17"`
+	F18 string `regex:"f18"`
+	F19 string `regex:"f19"`
+}
+
+var (
+	benchWidePattern    = bnGroupsPattern(20)
+	benchWideRe         = regexp.MustCompile(benchWidePattern)
+	benchWideInput      = bnWords(20)
+	benchWideMultiInput = strings.Repeat(bnWords(20)+"\n", 50) // 50 matches
+)
+
+// benchTime — exercises the time.Time fast path; first vs last layout in the
+// fallback list is the best/worst time-parse pair.
+type benchTime struct {
+	TS   time.Time     `regex:"ts"`
+	Took time.Duration `regex:"took"`
+}
+
+var (
+	benchTimeRe      = regexp.MustCompile(`(?P<ts>\S+) \((?P<took>\S+)\)`)
+	benchTimeFirstIn = "2026-04-26T12:34:56Z (1h30m)" // RFC3339Nano (layout 0) parses
+	benchTimeLastIn  = "12:34:56 (1h30m)"             // only TimeOnly (last layout) parses
+)
+
+// benchNumeric — int/uint/float/bool conversions in one struct.
+type benchNumeric struct {
+	I int     `regex:"i"`
+	U uint    `regex:"u"`
+	F float64 `regex:"f"`
+	B bool    `regex:"b"`
+}
+
+var (
+	benchNumericRe = regexp.MustCompile(`(?P<i>-?\d+) (?P<u>\d+) (?P<f>[\d.]+) (?P<b>\w+)`)
+	benchNumericIn = "-42 100 3.14 true"
+)
+
+// benchEmptyMatch — a group that matches an empty span (no default).
+type benchEmptyMatch struct {
+	Title string `regex:"title"`
+}
+
+var (
+	benchEmptyRe = regexp.MustCompile(`x(?P<title>\w*)x`)
+	benchEmptyIn = "xx"
+)
+
+// benchPointers — pointer fields (allocate-if-nil then recurse to builtin).
+type benchPointers struct {
+	Name *string `regex:"name"`
+	Age  *int    `regex:"age"`
+}
+
+var (
+	benchPtrRe = regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
+	benchPtrIn = "Alice is 30"
+)
+
+// benchCaseInsensitive — untagged fields resolved via the case-insensitive
+// field-name fallback in findGroupValue.
+type benchCaseInsensitive struct {
+	Name string
+	Age  int
+}
+
+var (
+	benchCIRe = regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
+	benchCIIn = "Alice is 30"
+)
+
+// benchDefault — group not declared, value supplied by default=.
+type benchDefault struct {
+	Role string `regex:"role,default=guest"`
+}
+
+var (
+	benchDefaultRe = regexp.MustCompile(`(?P<name>\w+)`)
+	benchDefaultIn = "Alice"
+)
+
+// RegexUnmarshaler fixtures covering the three setFieldValue dispatch branches:
+//   - benchCustom    : non-pointer field, dispatched via field.Addr() (line ~353)
+//   - benchCustomPtr : pointer field whose *T implements it, dispatched without
+//     recursing into the pointee (line ~343)
+//   - benchCustomVal : a value-receiver implementer; still dispatched via the
+//     addr branch because *T is also in the method set (line ~358's
+//     Type().Implements path is unreachable for addressable struct fields — a
+//     candidate for the issue #109 dead-code cleanup).
+type benchStatus int
+
+const (
+	benchStatusUnknown benchStatus = iota
+	benchStatusOpen
+	benchStatusClosed
+)
+
+func (s *benchStatus) UnmarshalRegex(value string) error {
+	switch value {
+	case "open":
+		*s = benchStatusOpen
+	case "closed":
+		*s = benchStatusClosed
+	default:
+		*s = benchStatusUnknown
+	}
+	return nil
+}
+
+type benchCustom struct {
+	State benchStatus `regex:"state"`
+}
+
+type benchCustomPtr struct {
+	State *benchStatus `regex:"state"`
+}
+
+type benchValStatus int
+
+func (s benchValStatus) UnmarshalRegex(string) error { return nil } // value receiver
+
+type benchCustomVal struct {
+	State benchValStatus `regex:"state"`
+}
+
+var (
+	benchCustomRe = regexp.MustCompile(`\[(?P<state>\w+)\]`)
+	benchCustomIn = "[open]"
+)
+
+// benchLayout — custom layout= on a time.Time field (no fallback list).
+type benchLayout struct {
+	TS time.Time `regex:"ts,layout=02/Jan/2006:15:04:05 -0700"`
+}
+
+var (
+	benchLayoutRe = regexp.MustCompile(`(?P<ts>.+)`)
+	benchLayoutIn = "26/Apr/2026:12:34:56 +0000"
+)
+
+// benchDuration — time.Duration conversion in isolation.
+type benchDuration struct {
+	D time.Duration `regex:"d"`
+}
+
+var (
+	benchDurRe = regexp.MustCompile(`(?P<d>\S+)`)
+	benchDurIn = "1h30m"
+)
+
+// benchBadInt — strconv.ParseInt error path (matched group, bad value).
+type benchBadInt struct {
+	Age int `regex:"age"`
+}
+
+var (
+	benchBadIntRe = regexp.MustCompile(`(?P<age>\w+)`)
+	benchBadIntIn = "notanumber"
+)
+
+// benchUnsupported — the setFieldValue default-case error (unsupported kind).
+type benchUnsupported struct {
+	C complex128 `regex:"c"`
+}
+
+var (
+	benchUnsupRe = regexp.MustCompile(`(?P<c>\S+)`)
+	benchUnsupIn = "1+2i"
+)
+
+// benchIntRow / benchLogLine — UnmarshalAll scaling corpora.
+type benchIntRow struct {
+	N int `regex:"n"`
+}
+
+var (
+	benchIntRowRe = regexp.MustCompile(`(?P<n>\d+)`)
+	benchIntRowIn = strings.TrimSpace(strings.Repeat("123 ", 1000)) // 1000 int rows
+)
+
+type benchLogLine struct {
+	Level string `regex:"level"`
+	Msg   string `regex:"msg"`
+}
+
+var (
+	benchLogRe = regexp.MustCompile(`\[(?P<level>\w+)\] (?P<msg>[^\n]+)`)
+	benchLogIn = strings.Repeat("[info] message body here\n", 100) // 100 log lines
+)
+
+// ── Unmarshal ─────────────────────────────────────────────────────────────────
+//
+// Cost model per call: argument-validation guard (reflect.Kind checks),
+// FindStringSubmatch, a groupValues map built from a SubexpNames loop, then
+// populateStruct iterating fields — each running parseFieldTag, findGroupValue,
+// and setFieldValue. setFieldValue dispatches: pointer → RegexUnmarshaler
+// (addr / value-receiver) → time.Time / time.Duration → kind switch
+// (string/int/uint/float/bool) → unsupported-type error.
+
+func BenchmarkUnmarshal(b *testing.B) {
+	// representative — the common shapes.
+	benchCase(b, "simpleThreeField", func() { var s benchSimple; sinkErr = rx.Unmarshal(benchSimpleRe, benchSimpleInput, &s) })
+	benchCase(b, "allNumericTypes", func() { var s benchNumeric; sinkErr = rx.Unmarshal(benchNumericRe, benchNumericIn, &s) })
+	benchCase(b, "customUnmarshaler", func() { var s benchCustom; sinkErr = rx.Unmarshal(benchCustomRe, benchCustomIn, &s) })
+	benchCase(b, "timeDurationField", func() { var s benchDuration; sinkErr = rx.Unmarshal(benchDurRe, benchDurIn, &s) })
+	// time best/worst pair — first layout hit vs full fallback-list walk.
+	benchCase(b, "timeFirstLayout", func() { var s benchTime; sinkErr = rx.Unmarshal(benchTimeRe, benchTimeFirstIn, &s) })
+	benchCase(b, "timeLastLayout", func() { var s benchTime; sinkErr = rx.Unmarshal(benchTimeRe, benchTimeLastIn, &s) })
+	benchCase(b, "layoutCustomTime", func() { var s benchLayout; sinkErr = rx.Unmarshal(benchLayoutRe, benchLayoutIn, &s) })
+	// edge — fallback resolution paths and the no-match contract shape.
+	benchCase(b, "noMatch", func() { var s benchSimple; sinkErr = rx.Unmarshal(benchSimpleRe, benchNoMatchInput, &s) })
+	benchCase(b, "emptyGroupMatch", func() { var s benchEmptyMatch; sinkErr = rx.Unmarshal(benchEmptyRe, benchEmptyIn, &s) })
+	benchCase(b, "caseInsensitiveFallback", func() { var s benchCaseInsensitive; sinkErr = rx.Unmarshal(benchCIRe, benchCIIn, &s) })
+	benchCase(b, "defaultValueFallback", func() { var s benchDefault; sinkErr = rx.Unmarshal(benchDefaultRe, benchDefaultIn, &s) })
+	// setFieldValue dispatch-branch coverage.
+	benchCase(b, "pointerFieldNil", func() { var s benchPointers; sinkErr = rx.Unmarshal(benchPtrRe, benchPtrIn, &s) })
+	benchCase(b, "pointerImplementsUnmarshaler", func() { var s benchCustomPtr; sinkErr = rx.Unmarshal(benchCustomRe, benchCustomIn, &s) })
+	benchCase(b, "valueReceiverUnmarshaler", func() { var s benchCustomVal; sinkErr = rx.Unmarshal(benchCustomRe, benchCustomIn, &s) })
+	// pointerFieldPreallocated needs non-nil pointers carried across iterations,
+	// so it can't share fresh-struct-per-call; written inline.
+	b.Run("pointerFieldPreallocated", func(b *testing.B) {
+		var p benchPointers
+		p.Name = new(string)
+		p.Age = new(int)
+		b.ReportAllocs()
+		for b.Loop() {
+			sinkErr = rx.Unmarshal(benchPtrRe, benchPtrIn, &p)
+		}
+	})
+	// scaling — per-field overhead with a 20-field struct.
+	benchCase(b, "wideStruct", func() { var s benchWide; sinkErr = rx.Unmarshal(benchWideRe, benchWideInput, &s) })
+	// error / guard paths — sink the error, do not fatal (the error IS the path).
+	benchCase(b, "invalidIntConversion", func() { var s benchBadInt; sinkErr = rx.Unmarshal(benchBadIntRe, benchBadIntIn, &s) })
+	benchCase(b, "unsupportedFieldType", func() { var s benchUnsupported; sinkErr = rx.Unmarshal(benchUnsupRe, benchUnsupIn, &s) })
+	benchCase(b, "invalidPointerArg", func() { sinkErr = rx.Unmarshal(benchSimpleRe, benchSimpleInput, benchSimpleVal) }) // non-pointer guard
+}
+
+// ── UnmarshalAll ──────────────────────────────────────────────────────────────
+//
+// Cost model: FindAllStringSubmatch (whole-target scan + index matrix), then
+// per match a groupValues map build + reflect.New + populateStruct, appended
+// into a slice grown via reflect.Append (incremental regrowth). Scales with
+// match count and per-match field/conversion work.
+
+func BenchmarkUnmarshalAll(b *testing.B) {
+	// edge / no-match contract shape (slice length set to 0).
+	benchCase(b, "noMatch", func() { var dst []benchSimple; sinkErr = rx.UnmarshalAll(benchSimpleRe, benchNoMatchInput, &dst) })
+	benchCase(b, "singleMatch", func() { var dst []benchSimple; sinkErr = rx.UnmarshalAll(benchSimpleRe, benchSimpleInput, &dst) })
+	// match-count scaling (matches100 aligns with DecoderAll/matches100).
+	benchCase(b, "matches10", func() { var dst []benchSimple; sinkErr = rx.UnmarshalAll(benchSimpleRe, benchBatch10Input, &dst) })
+	benchCase(b, "matches100", func() { var dst []benchSimple; sinkErr = rx.UnmarshalAll(benchSimpleRe, benchBatch100Input, &dst) })
+	benchCase(b, "matches1000", func() { var dst []benchSimple; sinkErr = rx.UnmarshalAll(benchSimpleRe, benchBatch1000Input, &dst) })
+	// per-field width and per-row conversion cost.
+	benchCase(b, "wideStruct", func() { var dst []benchWide; sinkErr = rx.UnmarshalAll(benchWideRe, benchWideMultiInput, &dst) })
+	benchCase(b, "manyIntConversions", func() { var dst []benchIntRow; sinkErr = rx.UnmarshalAll(benchIntRowRe, benchIntRowIn, &dst) })
+	benchCase(b, "realisticLogCorpus", func() { var dst []benchLogLine; sinkErr = rx.UnmarshalAll(benchLogRe, benchLogIn, &dst) })
+	// guard path — pointer to non-slice.
+	benchCase(b, "invalidSliceArg", func() { sinkErr = rx.UnmarshalAll(benchSimpleRe, benchSimpleInput, &benchSimpleVal) })
+}

--- a/regextra.go
+++ b/regextra.go
@@ -172,9 +172,10 @@ each function.
 package regextra
 
 import (
+	"cmp"
 	"fmt"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -192,12 +193,21 @@ func FindNamed(re *regexp.Regexp, target, groupName string) (string, bool) {
 		return "", false
 	}
 
-	matches := re.FindStringSubmatch(target)
-	if matches == nil {
+	// FindStringSubmatchIndex returns only the match offsets ([]int), so we can
+	// slice the one group we want out of target directly. FindStringSubmatch
+	// would additionally allocate a []string for every group just to discard
+	// all but one.
+	loc := re.FindStringSubmatchIndex(target)
+	if loc == nil {
 		return "", false
 	}
-
-	return matches[index], true
+	start, end := loc[2*index], loc[2*index+1]
+	if start < 0 {
+		// Group is declared but did not participate in the match; regexp's
+		// FindStringSubmatch would surface this as "" — preserve that.
+		return "", true
+	}
+	return target[start:end], true
 }
 
 // FindAllNamed returns every value of the named capture group across all
@@ -221,13 +231,20 @@ func FindAllNamed(re *regexp.Regexp, target, groupName string) []string {
 	if index == -1 {
 		return nil
 	}
-	matches := re.FindAllStringSubmatch(target, -1)
-	if len(matches) == 0 {
+	// Index form returns []int offsets per match; we slice the single group out
+	// of target rather than have FindAllStringSubmatch build a [][]string of
+	// every group across every match only to read one column of it.
+	locs := re.FindAllStringSubmatchIndex(target, -1)
+	if len(locs) == 0 {
 		return []string{}
 	}
-	out := make([]string, 0, len(matches))
-	for _, m := range matches {
-		out = append(out, m[index])
+	out := make([]string, len(locs))
+	for i, loc := range locs {
+		if s := loc[2*index]; s >= 0 {
+			out[i] = target[s:loc[2*index+1]]
+		}
+		// s < 0 → group did not participate in this match; leave out[i] == ""
+		// to match FindStringSubmatch's "" for a non-participating group.
 	}
 	return out
 }
@@ -341,9 +358,10 @@ func Replace(re *regexp.Regexp, target string, replacements map[string]string) s
 	}
 
 	var b strings.Builder
+	spans := make([]span, 0, len(names)) // reused across matches
 	cursor := 0
 	for _, m := range matches {
-		spans := make([]span, 0, len(names))
+		spans = spans[:0]
 		for i := 1; i < len(names); i++ {
 			name := names[i]
 			if name == "" {
@@ -359,7 +377,19 @@ func Replace(re *regexp.Regexp, target string, replacements map[string]string) s
 			}
 			spans = append(spans, span{start: s, end: e, repl: repl})
 		}
-		sort.Slice(spans, func(i, j int) bool { return spans[i].start < spans[j].start })
+		// Sort by start ascending, then end descending: when named groups share
+		// a start offset (nested groups), the outermost span — the one with the
+		// larger end — sorts first, claims the cursor, and the inner spans it
+		// encloses are skipped, making the documented "outermost wins" tie-break
+		// deterministic. The stable sort preserves declaration order for spans
+		// that are otherwise equal. (Fixes #107: the previous sort.Slice was
+		// unstable, so the tie-break was not guaranteed.)
+		slices.SortStableFunc(spans, func(a, c span) int {
+			if a.start != c.start {
+				return cmp.Compare(a.start, c.start)
+			}
+			return cmp.Compare(c.end, a.end)
+		})
 		for _, sp := range spans {
 			if sp.start < cursor {
 				continue // already covered (overlap with an earlier substitution)

--- a/regextra_test.go
+++ b/regextra_test.go
@@ -163,6 +163,16 @@ func TestFindAllNamed(t *testing.T) {
 			group:   "word",
 			want:    []string{},
 		},
+		{
+			// The requested group is optional and does not participate in every
+			// match; non-participating occurrences yield "" (matching what
+			// FindStringSubmatch reports for an unmatched group).
+			name:    "optional group, non-participating matches yield empty string",
+			pattern: `(?P<a>\w+)(?P<b>!)?`,
+			target:  "x! y z!",
+			group:   "b",
+			want:    []string{"!", "", "!"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -338,6 +348,24 @@ func TestReplace(t *testing.T) {
 			target:  "a 1 b 2 c 3 d",
 			repl:    map[string]string{"num": "*"},
 			want:    "a * b * c * d",
+		},
+		{
+			// Issue #107: nested named groups share a start offset, so the span
+			// sort must be deterministic. The outermost span (same start, larger
+			// end) wins; the inner group inside the already-replaced span is not
+			// substituted. The previous unstable sort.Slice made this flaky.
+			name:    "nested groups, outermost wins",
+			pattern: `(?P<outer>(?P<inner>\w+)@[\w.]+)`,
+			target:  "alice@example.com",
+			repl:    map[string]string{"outer": "REDACTED", "inner": "X"},
+			want:    "REDACTED",
+		},
+		{
+			name:    "nested groups, only inner group in map is substituted",
+			pattern: `(?P<outer>(?P<inner>\w+)@[\w.]+)`,
+			target:  "alice@example.com",
+			repl:    map[string]string{"inner": "X"},
+			want:    "X@example.com",
 		},
 	}
 	for _, tt := range tests {

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -149,29 +149,24 @@ func UnmarshalAll(re *regexp.Regexp, target string, v any) error {
 		return nil
 	}
 
-	// Create a new slice with capacity for all matches
-	newSlice := reflect.MakeSlice(elem.Type(), 0, len(allMatches))
-
-	// Process each match
-	for _, matches := range allMatches {
-		// Build a map of capture group names to their values for this match
-		groupValues := make(map[string]string)
-		for i, name := range re.SubexpNames() {
+	// SubexpNames is identical for every match, so fetch it once instead of per
+	// match. Reuse a single groupValues map (cleared each iteration) rather than
+	// allocating one per match, and size the result slice up front so each match
+	// decodes into place — avoiding the reflect.New + reflect.Append copy the
+	// previous append-grow loop paid per match.
+	names := re.SubexpNames()
+	newSlice := reflect.MakeSlice(elem.Type(), len(allMatches), len(allMatches))
+	groupValues := make(map[string]string, len(names))
+	for idx, matches := range allMatches {
+		clear(groupValues)
+		for i, name := range names {
 			if i != 0 && name != "" {
 				groupValues[name] = matches[i]
 			}
 		}
-
-		// Create a new struct instance
-		structValue := reflect.New(sliceElemType).Elem()
-
-		// Populate the struct fields
-		if err := populateStruct(structValue, groupValues); err != nil {
+		if err := populateStruct(newSlice.Index(idx), groupValues); err != nil {
 			return err
 		}
-
-		// Append to the slice
-		newSlice = reflect.Append(newSlice, structValue)
 	}
 
 	// Set the slice to the new value


### PR DESCRIPTION
## Summary

Adds a comprehensive benchmark suite for the package's exported surface, then uses it to land three allocation-focused optimizations (one of which also fixes a documented correctness bug, #107), plus a CI leg that runs the suite on the latest Go.

Designed bottom-up: benchmarks first, optimizations proven against them with `benchstat`.

## Commits (reviewable in order)

1. **`test(bench)`** — benchmark suite (`bench_*.go`): one `Benchmark<Func>` per exported function, flat `b.Run` sub-cases spanning a representative size/match-count distribution plus every edge corner (no-match contract shapes, optional/empty/duplicate groups, unicode, time-layout best/worst, each `setFieldValue` branch, arg guards). Package-level fixtures keep construction out of the measured loop; head-to-head pairs share byte-identical inputs. `bench_sanity_test.go` asserts fixtures hit their intended path; `bench_internal_test.go` isolates the `compileDecoder` plan cost from `regexp.Compile`.
2. **`perf(unmarshal)`** — `UnmarshalAll`: hoist `SubexpNames` out of the per-match loop, reuse one cleared map, decode in place. Behavior unchanged.
3. **`perf(regextra)`** — `FindNamed`/`FindAllNamed` extract one group via `…SubmatchIndex` instead of building the full submatch; `Replace` swaps the unstable `sort.Slice` for `slices.SortStableFunc` (start asc, end desc). **Fixes #107** (deterministic "outermost wins").
4. **`ci`** — benchmarks workflow on Go 1.26 (job-summary output, non-gating).

## Measured wins (benchstat, n=8, Apple M4)

| Path | allocs/op | time |
|---|---|---|
| `Replace` (100 matches) | **−63%** (315→116) | −13% |
| `Replace` (large input) | **−66%** (3627→1228) | −7% |
| `FindNamed` (all match cases) | **−50%** (2→1) | −6…14% |
| `FindAllNamed` (scaling ladder) | **−50%** | −11…16% |
| `UnmarshalAll` (100 matches) | −28% (708→508) | −5% |
| `UnmarshalAll` (wide struct) | −24%, **−59% bytes** | −15% |

No regressions on early-return/no-match paths.

## Correctness

- Full suite + `-race` + `go vet` green
- 2.87M `FuzzFindNamed` executions against the new index path — no failures
- New regression tests: 2 nested-group cases pinning #107, 1 optional-non-participating-group case for `FindAllNamed`
- `go.mod` stays at `go 1.24` (no consumer-floor change)

## Notes

- `Replace`'s `slices.SortStableFunc` change is what makes the documented outermost-wins tie-break deterministic; the alloc reduction rides along with it.
- Cross-toolchain *testing* (1.24/1.25/1.26) already exists in `test.yml`; the new workflow is the dedicated *performance* leg on latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a CI Benchmarks workflow that runs Go benchmarks and publishes a readable results summary in the workflow view.
- **Performance**
  - Improved regex named-group extraction and bulk unmarshalling to reduce allocations and speed up repeated processing.
  - Enhanced replacement logic for more consistent ordering in overlapping/nested cases.
- **Bug Fixes**
  - Preserved existing behavior for declared-but-nonparticipating capture groups and ensured non-matches return the expected empty results.
- **CI / Security**
  - Made CI workflows safer for forked pull requests and reduced credential exposure by using read-only checkouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->