### PR TITLE
test(unmarshal): pin tag-grammar forward-compat rules (#113)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,28 @@ gofmt -s -l .
 - Test edge cases (nil pointers, empty strings, no matches)
 - Add example tests for public APIs (they appear in godoc)
 
+#### Test the public contract, not internals
+- **Assert observable behavior through the exported API** (`Unmarshal`,
+  `UnmarshalAll`, `Compile`/`Decoder`, etc.), never the internals of an
+  unexported function. If a behavior matters, it is reachable from the public
+  surface — drive it from there so tests survive refactors of the internals.
+  Behavior that looks invisible usually isn't: a forward-compat rule like "an
+  unknown tag option is ignored" is observable as a no-op — pair it with a
+  visible effect such as `default=` to prove the parser accepted it.
+- **Do not pin implementation detail** — private field shapes, whether a map
+  is nil vs empty, or intermediate parser state. Pinning internals makes tests
+  brittle and turns harmless refactors into false regressions.
+- The rule is about what you *assert*, not the package clause. A test in
+  `package regextra` (rather than `package regextra_test`) is fine when it
+  still asserts observable behavior — several existing files do this only to
+  drop the `rx.` qualifier. It is not a license to read unexported state.
+- If a unit ever genuinely needs isolation the public API can't reach,
+  introduce a seam — an interface or injected dependency, with a fake/stub in
+  the test — instead of reaching inside. (regextra is a pure library today, so
+  this is rare.) Benchmarks that must measure unexported cost, like
+  `bench_internal_test.go`, are the one accepted reason to live inside the
+  package and touch internals.
+
 ### Documentation
 - **All exported functions must have godoc comments**
 - Start with the function name: `// FunctionName does...`

--- a/regextra.go
+++ b/regextra.go
@@ -153,8 +153,8 @@ Two forward-compatibility rules in [parseFieldTag] are part of the v1 contract:
     recognized set.
 
   - Lone tokens (no `=`) are silently ignored. Today, `regex:"name,foo"`
-    parses as (name="name", opts={}) — the `foo` token is dropped, leaving
-    an empty (non-nil) opts map. This
+    is a no-op — the `foo` token is dropped, so the field resolves exactly as
+    `regex:"name"` would. This
     slot is reserved for future flag-style options (e.g. `required`; see
     ROADMAP.md). A later minor release may start recognizing specific lone
     tokens and giving them meaning, so adding `regex:"name,foo"` today is a

--- a/regextra.go
+++ b/regextra.go
@@ -142,7 +142,7 @@ Only the bare `-` tag excludes. A leading `-` followed by options
 (e.g. `regex:"-,default=x"`) parses `-` as the group name, which matches no
 group since regexp group names are Go identifiers.
 
-Two forward-compatibility rules in [parseFieldTag] are part of the v1 contract:
+Two forward-compatibility rules in the tag parser are part of the v1 contract:
 
   - Unknown key=value pairs are preserved, not rejected. The parser stores
     every key=value pair regardless of whether the key is currently

--- a/regextra.go
+++ b/regextra.go
@@ -153,7 +153,8 @@ Two forward-compatibility rules in [parseFieldTag] are part of the v1 contract:
     recognized set.
 
   - Lone tokens (no `=`) are silently ignored. Today, `regex:"name,foo"`
-    parses as (name="name", opts=nil) — the `foo` token is dropped. This
+    parses as (name="name", opts={}) — the `foo` token is dropped, leaving
+    an empty (non-nil) opts map. This
     slot is reserved for future flag-style options (e.g. `required`; see
     ROADMAP.md). A later minor release may start recognizing specific lone
     tokens and giving them meaning, so adding `regex:"name,foo"` today is a

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -257,14 +257,14 @@ func parseFieldTag(field reflect.StructField) (name string, opts map[string]stri
 	opts = make(map[string]string, len(parts)-1)
 	for _, p := range parts[1:] {
 		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
 		k, v, ok := strings.Cut(p, "=")
 		if !ok {
-			// Lone token without '='. Reserved for future flag-style options;
-			// silently ignored today rather than rejected to keep the parser
-			// forward-compatible.
+			// No '=': either a lone token (reserved for future flag-style
+			// options, e.g. `required`) or an empty piece (a doubled, leading,
+			// or trailing comma). Both are silently ignored rather than rejected
+			// to keep the parser forward-compatible. An empty piece needs no
+			// separate guard: strings.Cut("", "=") returns ok=false, so it lands
+			// here too.
 			continue
 		}
 		opts[strings.TrimSpace(k)] = strings.TrimSpace(v)

--- a/unmarshal_tag_test.go
+++ b/unmarshal_tag_test.go
@@ -1,213 +1,79 @@
-package regextra
+package regextra_test
 
 import (
-	"reflect"
-	"strings"
+	"regexp"
 	"testing"
+
+	rx "github.com/jecoms/regextra"
 )
 
 // Issue #113: pin the two tag-grammar forward-compatibility rules that the
-// package doc (regextra.go "Tag grammar") declares part of the v1 contract:
+// package doc (regextra.go "Tag grammar") declares part of the v1 contract,
+// exercised through the public Unmarshal surface rather than the unexported
+// parser:
 //
 //   - Unknown key=value pairs are preserved, not rejected, so a future minor
 //     release can recognize new option keys without a parser change.
-//   - Lone tokens (no `=`) are silently ignored, reserving that slot for
+//   - Lone tokens (no '=') are silently ignored, reserving that slot for
 //     future flag-style options (e.g. `required`).
 //
-// Both branches in parseFieldTag (the empty-piece skip and the lone-token
-// drop) were previously uncovered; these tests lock the behavior in so the
-// contract can't regress silently.
+// Each rule is observable only as a no-op today: the extra option carries no
+// meaning, so the field resolves exactly as if it were absent. Pairing the
+// forward-compat piece with a `default` on an absent group makes that visible
+// — the default still applies, proving the parser neither errored on nor was
+// derailed by the extra piece.
 
-// fieldWithTag builds a reflect.StructField carrying the given regex tag.
-// parseFieldTag only reads field.Tag, so this is enough to exercise it
-// directly without constructing a whole regexp/Unmarshal round trip.
-func fieldWithTag(tag string) reflect.StructField {
-	return reflect.StructField{
-		Name: "F",
-		Type: reflect.TypeOf(""),
-		Tag:  reflect.StructTag(`regex:"` + tag + `"`),
+func TestUnmarshal_unknownOptionKeyIsAccepted(t *testing.T) {
+	// Forward-compat rule 1: an unrecognized key=value must not be rejected.
+	// `future` has no meaning today, so the field matches its group exactly as
+	// if the option were absent.
+	type Person struct {
+		Name string `regex:"name,future=42"`
+	}
+	re := regexp.MustCompile(`(?P<name>\w+)`)
+
+	var p Person
+	if err := rx.Unmarshal(re, "Alice", &p); err != nil {
+		t.Fatalf("Unmarshal() error = %v, want nil (unknown option keys must be accepted, not rejected)", err)
+	}
+	if p.Name != "Alice" {
+		t.Errorf("Name = %q, want %q", p.Name, "Alice")
 	}
 }
 
-func TestParseFieldTag(t *testing.T) {
-	tests := []struct {
-		name     string
-		tag      string
-		wantName string
-		wantOpts map[string]string
-		wantSkip bool
-	}{
-		{
-			name:     "empty tag falls back to field name",
-			tag:      "",
-			wantName: "",
-			wantOpts: nil,
-			wantSkip: false,
-		},
-		{
-			name:     "bare dash excludes",
-			tag:      "-",
-			wantName: "",
-			wantOpts: nil,
-			wantSkip: true,
-		},
-		{
-			name:     "lone name only",
-			tag:      "name",
-			wantName: "name",
-			wantOpts: nil,
-			wantSkip: false,
-		},
-		{
-			name:     "recognized key=value",
-			tag:      "name,default=x",
-			wantName: "name",
-			wantOpts: map[string]string{"default": "x"},
-			wantSkip: false,
-		},
-		{
-			// Forward-compat rule 1: an unknown key is stored verbatim, not
-			// rejected, so a later minor can give it meaning.
-			name:     "unknown key=value preserved",
-			tag:      "name,future=42",
-			wantName: "name",
-			wantOpts: map[string]string{"future": "42"},
-			wantSkip: false,
-		},
-		{
-			// Forward-compat rule 2: a lone token (no '=') is dropped today.
-			// opts is allocated because there is a second piece, but stays
-			// empty — the lone token leaves nothing behind.
-			name:     "lone token is ignored",
-			tag:      "name,required",
-			wantName: "name",
-			wantOpts: map[string]string{},
-			wantSkip: false,
-		},
-		{
-			// A lone token and a recognized key=value in the same tag: the
-			// lone token is dropped, the key=value survives.
-			name:     "lone token dropped while a key=value is kept",
-			tag:      "name,a,b=2",
-			wantName: "name",
-			wantOpts: map[string]string{"b": "2"},
-			wantSkip: false,
-		},
-		{
-			// Empty pieces between commas are skipped without affecting opts.
-			name:     "empty piece is skipped",
-			tag:      "name,,default=x",
-			wantName: "name",
-			wantOpts: map[string]string{"default": "x"},
-			wantSkip: false,
-		},
-		{
-			// Whitespace inside a key=value is trimmed on both sides of '='.
-			name:     "whitespace around key and value is trimmed",
-			tag:      " name , default = x ",
-			wantName: "name",
-			wantOpts: map[string]string{"default": "x"},
-			wantSkip: false,
-		},
-		{
-			// Both rules together plus surrounding whitespace: lone token
-			// dropped, empty piece skipped, key=value kept and trimmed.
-			name:     "lone token and empty piece alongside a real option",
-			tag:      "name, required ,, layout=2006 ",
-			wantName: "name",
-			wantOpts: map[string]string{"layout": "2006"},
-			wantSkip: false,
-		},
-		{
-			// Leading "-" with options is NOT an exclude: "-" parses as the
-			// group name (matches no group), per the documented boundary.
-			name:     "dash with options is a group name, not exclude",
-			tag:      "-,default=x",
-			wantName: "-",
-			wantOpts: map[string]string{"default": "x"},
-			wantSkip: false,
-		},
+func TestUnmarshal_loneTokenIsIgnored(t *testing.T) {
+	// Forward-compat rule 2: a lone token (no '=') is silently ignored today,
+	// reserving the slot for future flag-style options. `required` has no
+	// meaning yet, so it neither errors nor blocks the `default` that follows
+	// it — the "role" group is absent, so the field takes the default.
+	type Person struct {
+		Role string `regex:"role,required,default=guest"`
 	}
+	re := regexp.MustCompile(`(?P<name>\w+)`) // no "role" group
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			name, opts, skip := parseFieldTag(fieldWithTag(tt.tag))
-			if name != tt.wantName {
-				t.Errorf("name = %q, want %q", name, tt.wantName)
-			}
-			if skip != tt.wantSkip {
-				t.Errorf("skip = %v, want %v", skip, tt.wantSkip)
-			}
-			if !reflect.DeepEqual(opts, tt.wantOpts) {
-				t.Errorf("opts = %#v, want %#v", opts, tt.wantOpts)
-			}
-		})
+	var p Person
+	if err := rx.Unmarshal(re, "Alice", &p); err != nil {
+		t.Fatalf("Unmarshal() error = %v, want nil (a lone token must be ignored)", err)
+	}
+	if p.Role != "guest" {
+		t.Errorf("Role = %q, want %q (lone token ignored; default still applies)", p.Role, "guest")
 	}
 }
 
-// FuzzParseFieldTag drives parseFieldTag with arbitrary tag bodies and asserts
-// the structural invariants the v1 contract rests on, rather than re-deriving
-// the expected output (which would just duplicate the parser).
-func FuzzParseFieldTag(f *testing.F) {
-	for _, s := range []string{
-		"", "-", "name", "name,default=x", "name,required",
-		"name,,default=x", "-,default=x", " name , a=b ", "=", ",", "a=b=c",
-	} {
-		f.Add(s)
+func TestUnmarshal_emptyOptionPieceIsSkipped(t *testing.T) {
+	// An empty piece between commas (here a doubled comma) is skipped without
+	// disturbing the options around it: the `default` after it is still
+	// recognized when the group is absent.
+	type Person struct {
+		Role string `regex:"role,,default=guest"`
 	}
+	re := regexp.MustCompile(`(?P<name>\w+)`) // no "role" group
 
-	f.Fuzz(func(t *testing.T, rawTag string) {
-		field := fieldWithTag(rawTag)
-		// Embedding rawTag in a struct-tag literal does not round-trip when it
-		// contains quotes or backslashes, so assert against the value the
-		// parser actually reads — the same Tag.Get call parseFieldTag makes.
-		tag := field.Tag.Get("regex")
-
-		name, opts, skip := parseFieldTag(field)
-
-		// Only the bare "-" excludes; nothing else does.
-		if skip != (tag == "-") {
-			t.Fatalf("skip = %v for tag %q, want %v", skip, tag, tag == "-")
-		}
-		// An excluded field carries no name and no options.
-		if skip {
-			if name != "" || opts != nil {
-				t.Fatalf("excluded tag %q yielded name=%q opts=%#v, want empty", tag, name, opts)
-			}
-			return
-		}
-		// The name is always the trimmed first comma-piece.
-		if want := strings.TrimSpace(strings.Split(tag, ",")[0]); name != want {
-			t.Fatalf("name = %q for tag %q, want %q", name, tag, want)
-		}
-		// opts is allocated iff there is at least one option piece, regardless
-		// of whether any piece survived parsing (lone tokens / empties leave an
-		// allocated-but-empty map). A single-piece tag yields a nil opts.
-		single := !strings.Contains(tag, ",")
-		if single && opts != nil {
-			t.Fatalf("single-piece tag %q yielded non-nil opts %#v", tag, opts)
-		}
-		if !single && opts == nil {
-			t.Fatalf("multi-piece tag %q yielded nil opts", tag)
-		}
-		// Every stored key=value came from a piece containing '='; a lone
-		// token (no '=') must never appear as a key.
-		for k := range opts {
-			if k == "" {
-				continue // "=value" cuts to an empty key; allowed, just not a lone token
-			}
-			found := false
-			for _, p := range strings.Split(tag, ",")[1:] {
-				p = strings.TrimSpace(p)
-				ck, _, ok := strings.Cut(p, "=")
-				if ok && strings.TrimSpace(ck) == k {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Fatalf("opts key %q in tag %q did not come from a key=value piece", k, tag)
-			}
-		}
-	})
+	var p Person
+	if err := rx.Unmarshal(re, "Alice", &p); err != nil {
+		t.Fatalf("Unmarshal() error = %v, want nil", err)
+	}
+	if p.Role != "guest" {
+		t.Errorf("Role = %q, want %q (empty piece skipped; default still applies)", p.Role, "guest")
+	}
 }

--- a/unmarshal_tag_test.go
+++ b/unmarshal_tag_test.go
@@ -85,9 +85,26 @@ func TestParseFieldTag(t *testing.T) {
 			wantSkip: false,
 		},
 		{
+			// A lone token and a recognized key=value in the same tag: the
+			// lone token is dropped, the key=value survives.
+			name:     "lone token dropped while a key=value is kept",
+			tag:      "name,a,b=2",
+			wantName: "name",
+			wantOpts: map[string]string{"b": "2"},
+			wantSkip: false,
+		},
+		{
 			// Empty pieces between commas are skipped without affecting opts.
 			name:     "empty piece is skipped",
 			tag:      "name,,default=x",
+			wantName: "name",
+			wantOpts: map[string]string{"default": "x"},
+			wantSkip: false,
+		},
+		{
+			// Whitespace inside a key=value is trimmed on both sides of '='.
+			name:     "whitespace around key and value is trimmed",
+			tag:      " name , default = x ",
 			wantName: "name",
 			wantOpts: map[string]string{"default": "x"},
 			wantSkip: false,

--- a/unmarshal_tag_test.go
+++ b/unmarshal_tag_test.go
@@ -1,0 +1,196 @@
+package regextra
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Issue #113: pin the two tag-grammar forward-compatibility rules that the
+// package doc (regextra.go "Tag grammar") declares part of the v1 contract:
+//
+//   - Unknown key=value pairs are preserved, not rejected, so a future minor
+//     release can recognize new option keys without a parser change.
+//   - Lone tokens (no `=`) are silently ignored, reserving that slot for
+//     future flag-style options (e.g. `required`).
+//
+// Both branches in parseFieldTag (the empty-piece skip and the lone-token
+// drop) were previously uncovered; these tests lock the behavior in so the
+// contract can't regress silently.
+
+// fieldWithTag builds a reflect.StructField carrying the given regex tag.
+// parseFieldTag only reads field.Tag, so this is enough to exercise it
+// directly without constructing a whole regexp/Unmarshal round trip.
+func fieldWithTag(tag string) reflect.StructField {
+	return reflect.StructField{
+		Name: "F",
+		Type: reflect.TypeOf(""),
+		Tag:  reflect.StructTag(`regex:"` + tag + `"`),
+	}
+}
+
+func TestParseFieldTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		tag      string
+		wantName string
+		wantOpts map[string]string
+		wantSkip bool
+	}{
+		{
+			name:     "empty tag falls back to field name",
+			tag:      "",
+			wantName: "",
+			wantOpts: nil,
+			wantSkip: false,
+		},
+		{
+			name:     "bare dash excludes",
+			tag:      "-",
+			wantName: "",
+			wantOpts: nil,
+			wantSkip: true,
+		},
+		{
+			name:     "lone name only",
+			tag:      "name",
+			wantName: "name",
+			wantOpts: nil,
+			wantSkip: false,
+		},
+		{
+			name:     "recognized key=value",
+			tag:      "name,default=x",
+			wantName: "name",
+			wantOpts: map[string]string{"default": "x"},
+			wantSkip: false,
+		},
+		{
+			// Forward-compat rule 1: an unknown key is stored verbatim, not
+			// rejected, so a later minor can give it meaning.
+			name:     "unknown key=value preserved",
+			tag:      "name,future=42",
+			wantName: "name",
+			wantOpts: map[string]string{"future": "42"},
+			wantSkip: false,
+		},
+		{
+			// Forward-compat rule 2: a lone token (no '=') is dropped today.
+			// opts is allocated because there is a second piece, but stays
+			// empty — the lone token leaves nothing behind.
+			name:     "lone token is ignored",
+			tag:      "name,required",
+			wantName: "name",
+			wantOpts: map[string]string{},
+			wantSkip: false,
+		},
+		{
+			// Empty pieces between commas are skipped without affecting opts.
+			name:     "empty piece is skipped",
+			tag:      "name,,default=x",
+			wantName: "name",
+			wantOpts: map[string]string{"default": "x"},
+			wantSkip: false,
+		},
+		{
+			// Both rules together plus surrounding whitespace: lone token
+			// dropped, empty piece skipped, key=value kept and trimmed.
+			name:     "lone token and empty piece alongside a real option",
+			tag:      "name, required ,, layout=2006 ",
+			wantName: "name",
+			wantOpts: map[string]string{"layout": "2006"},
+			wantSkip: false,
+		},
+		{
+			// Leading "-" with options is NOT an exclude: "-" parses as the
+			// group name (matches no group), per the documented boundary.
+			name:     "dash with options is a group name, not exclude",
+			tag:      "-,default=x",
+			wantName: "-",
+			wantOpts: map[string]string{"default": "x"},
+			wantSkip: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, opts, skip := parseFieldTag(fieldWithTag(tt.tag))
+			if name != tt.wantName {
+				t.Errorf("name = %q, want %q", name, tt.wantName)
+			}
+			if skip != tt.wantSkip {
+				t.Errorf("skip = %v, want %v", skip, tt.wantSkip)
+			}
+			if !reflect.DeepEqual(opts, tt.wantOpts) {
+				t.Errorf("opts = %#v, want %#v", opts, tt.wantOpts)
+			}
+		})
+	}
+}
+
+// FuzzParseFieldTag drives parseFieldTag with arbitrary tag bodies and asserts
+// the structural invariants the v1 contract rests on, rather than re-deriving
+// the expected output (which would just duplicate the parser).
+func FuzzParseFieldTag(f *testing.F) {
+	for _, s := range []string{
+		"", "-", "name", "name,default=x", "name,required",
+		"name,,default=x", "-,default=x", " name , a=b ", "=", ",", "a=b=c",
+	} {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, rawTag string) {
+		field := fieldWithTag(rawTag)
+		// Embedding rawTag in a struct-tag literal does not round-trip when it
+		// contains quotes or backslashes, so assert against the value the
+		// parser actually reads — the same Tag.Get call parseFieldTag makes.
+		tag := field.Tag.Get("regex")
+
+		name, opts, skip := parseFieldTag(field)
+
+		// Only the bare "-" excludes; nothing else does.
+		if skip != (tag == "-") {
+			t.Fatalf("skip = %v for tag %q, want %v", skip, tag, tag == "-")
+		}
+		// An excluded field carries no name and no options.
+		if skip {
+			if name != "" || opts != nil {
+				t.Fatalf("excluded tag %q yielded name=%q opts=%#v, want empty", tag, name, opts)
+			}
+			return
+		}
+		// The name is always the trimmed first comma-piece.
+		if want := strings.TrimSpace(strings.Split(tag, ",")[0]); name != want {
+			t.Fatalf("name = %q for tag %q, want %q", name, tag, want)
+		}
+		// opts is allocated iff there is at least one option piece, regardless
+		// of whether any piece survived parsing (lone tokens / empties leave an
+		// allocated-but-empty map). A single-piece tag yields a nil opts.
+		single := !strings.Contains(tag, ",")
+		if single && opts != nil {
+			t.Fatalf("single-piece tag %q yielded non-nil opts %#v", tag, opts)
+		}
+		if !single && opts == nil {
+			t.Fatalf("multi-piece tag %q yielded nil opts", tag)
+		}
+		// Every stored key=value came from a piece containing '='; a lone
+		// token (no '=') must never appear as a key.
+		for k := range opts {
+			if k == "" {
+				continue // "=value" cuts to an empty key; allowed, just not a lone token
+			}
+			found := false
+			for _, p := range strings.Split(tag, ",")[1:] {
+				p = strings.TrimSpace(p)
+				ck, _, ok := strings.Cut(p, "=")
+				if ok && strings.TrimSpace(ck) == k {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("opts key %q in tag %q did not come from a key=value piece", k, tag)
+			}
+		}
+	})
+}

--- a/unmarshal_tag_test.go
+++ b/unmarshal_tag_test.go
@@ -9,10 +9,10 @@ import (
 
 // Issue #113: pin the two tag-grammar forward-compatibility rules that the
 // package doc (regextra.go "Tag grammar") declares part of the v1 contract,
-// exercised through the public Unmarshal surface rather than the unexported
-// parser:
+// exercised through the public Unmarshal/Decoder surface rather than the
+// unexported parser:
 //
-//   - Unknown key=value pairs are preserved, not rejected, so a future minor
+//   - Unknown key=value pairs are accepted, not rejected, so a future minor
 //     release can recognize new option keys without a parser change.
 //   - Lone tokens (no '=') are silently ignored, reserving that slot for
 //     future flag-style options (e.g. `required`).
@@ -21,7 +21,9 @@ import (
 // meaning, so the field resolves exactly as if it were absent. Pairing the
 // forward-compat piece with a `default` on an absent group makes that visible
 // — the default still applies, proving the parser neither errored on nor was
-// derailed by the extra piece.
+// derailed by the extra piece. (Whether an unknown key is retained in the
+// internal option map is not observable through the public API, so the tests
+// pin only that such keys are accepted, not that they are stored.)
 
 func TestUnmarshal_unknownOptionKeyIsAccepted(t *testing.T) {
 	// Forward-compat rule 1: an unrecognized key=value must not be rejected.
@@ -61,19 +63,76 @@ func TestUnmarshal_loneTokenIsIgnored(t *testing.T) {
 }
 
 func TestUnmarshal_emptyOptionPieceIsSkipped(t *testing.T) {
-	// An empty piece between commas (here a doubled comma) is skipped without
-	// disturbing the options around it: the `default` after it is still
-	// recognized when the group is absent.
-	type Person struct {
-		Role string `regex:"role,,default=guest"`
-	}
-	re := regexp.MustCompile(`(?P<name>\w+)`) // no "role" group
+	// An empty option piece is skipped without disturbing the options around
+	// it: the `default` still resolves when the group is absent. The skip
+	// applies the same way wherever the empty piece falls, so these positional
+	// variants share subtests (struct tags are compile-time literals, so each
+	// needs its own struct rather than a value table). This pins the observable
+	// behavior, not a specific parser branch — an empty piece is inert whether
+	// the dedicated skip handles it or it falls through the lone-token path.
+	re := regexp.MustCompile(`(?P<name>\w+)`) // no "role" group; default fires
 
-	var p Person
-	if err := rx.Unmarshal(re, "Alice", &p); err != nil {
-		t.Fatalf("Unmarshal() error = %v, want nil", err)
+	t.Run("doubled comma", func(t *testing.T) {
+		type Person struct {
+			Role string `regex:"role,,default=guest"`
+		}
+		var p Person
+		if err := rx.Unmarshal(re, "Alice", &p); err != nil {
+			t.Fatalf("Unmarshal() error = %v, want nil", err)
+		}
+		if p.Role != "guest" {
+			t.Errorf("Role = %q, want %q (empty piece skipped; default still applies)", p.Role, "guest")
+		}
+	})
+
+	t.Run("trailing comma", func(t *testing.T) {
+		type Person struct {
+			Role string `regex:"role,default=guest,"`
+		}
+		var p Person
+		if err := rx.Unmarshal(re, "Alice", &p); err != nil {
+			t.Fatalf("Unmarshal() error = %v, want nil", err)
+		}
+		if p.Role != "guest" {
+			t.Errorf("Role = %q, want %q (trailing empty piece skipped)", p.Role, "guest")
+		}
+	})
+
+	t.Run("whitespace-only piece", func(t *testing.T) {
+		type Person struct {
+			Role string `regex:"role, ,default=guest"`
+		}
+		var p Person
+		if err := rx.Unmarshal(re, "Alice", &p); err != nil {
+			t.Fatalf("Unmarshal() error = %v, want nil", err)
+		}
+		if p.Role != "guest" {
+			t.Errorf("Role = %q, want %q (whitespace-only piece skipped)", p.Role, "guest")
+		}
+	})
+}
+
+// parseFieldTag feeds the Decoder/Compile path too, so the same forward-compat
+// no-ops must hold there. Parsing happens once at compile time and One/All/Iter
+// share that result, so a single One probe is sufficient parity coverage.
+func TestDecoder_tagForwardCompatRules(t *testing.T) {
+	type Person struct {
+		Name string `regex:"name,future=42"`              // unknown key: accepted, not rejected
+		Role string `regex:"role,required,default=guest"` // lone token: ignored; default applies
+	}
+	d, err := rx.Compile[Person](`(?P<name>\w+)`) // no "role" group; default fires
+	if err != nil {
+		t.Fatalf("Compile() error = %v, want nil (forward-compat options must not break compilation)", err)
+	}
+
+	p, err := d.One("Alice")
+	if err != nil {
+		t.Fatalf("One() error = %v", err)
+	}
+	if p.Name != "Alice" {
+		t.Errorf("Name = %q, want %q", p.Name, "Alice")
 	}
 	if p.Role != "guest" {
-		t.Errorf("Role = %q, want %q (empty piece skipped; default still applies)", p.Role, "guest")
+		t.Errorf("Role = %q, want %q (lone token ignored; default applies on the Decoder path)", p.Role, "guest")
 	}
 }

--- a/unmarshal_tag_test.go
+++ b/unmarshal_tag_test.go
@@ -63,13 +63,12 @@ func TestUnmarshal_loneTokenIsIgnored(t *testing.T) {
 }
 
 func TestUnmarshal_emptyOptionPieceIsSkipped(t *testing.T) {
-	// An empty option piece is skipped without disturbing the options around
-	// it: the `default` still resolves when the group is absent. The skip
-	// applies the same way wherever the empty piece falls, so these positional
+	// An empty option piece is ignored without disturbing the options around
+	// it: the `default` still resolves when the group is absent. The behavior
+	// holds the same way wherever the empty piece falls, so these positional
 	// variants share subtests (struct tags are compile-time literals, so each
-	// needs its own struct rather than a value table). This pins the observable
-	// behavior, not a specific parser branch — an empty piece is inert whether
-	// the dedicated skip handles it or it falls through the lone-token path.
+	// needs its own struct rather than a value table). An empty piece has no
+	// '=', so the parser drops it via the same path as a lone token.
 	re := regexp.MustCompile(`(?P<name>\w+)`) // no "role" group; default fires
 
 	t.Run("doubled comma", func(t *testing.T) {


### PR DESCRIPTION
## Summary
Pin the two tag-grammar forward-compatibility rules the package doc declares part of the v1 contract — **through the public `Unmarshal` surface**, not the unexported parser. (An earlier revision tested `parseFieldTag` directly; per review this was reworked to assert the observable contract instead, so the tests survive internal refactors. See #70, which had deliberately dropped the direct parser test.)

- **Unknown `key=value` is accepted, not rejected** (`regex:"name,future=42"`) — proven by `Unmarshal` succeeding and the field still matching its group.
- **A lone token is ignored** (`regex:"role,required,default=guest"`) — proven by the `default` still applying on an absent group, so the token neither errored nor derailed parsing.
- **An empty option piece is ignored** (`regex:"role,,default=guest"`, plus trailing/whitespace-only positions as subtests) — same observable proof.

Each rule is a no-op today, so it's pinned via a *visible* effect (`default=` on an absent group) rather than by inspecting internal parser state. Still lifts `parseFieldTag` from 88.2% to **100%** coverage through the public API alone.

Also in this PR:
- **Decoder parity**: `TestDecoder_tagForwardCompatRules` locks the same no-ops on the `Compile`/`Decoder` path (parsing happens once at compile time, so a single `One` probe suffices).
- **Package doc**: the lone-token example now describes the observable no-op (`regex:"name,foo"` resolves as `regex:"name"` would) instead of the internal opts-map shape.
- **Parser cleanup** (`refactor` commit): drops the redundant empty-piece skip in `parseFieldTag` — `strings.Cut("", "=")` already returns `ok=false`, so the lone-token branch drops empty pieces identically. Verified dead by a differential fuzz (12M execs, zero divergence) plus an independent `strings.Cut`-semantics audit; no input yields a different `(name, opts, skip)`.
- **CONTRIBUTING.md**: codifies "test the public contract, not internals," with a seam/DI escape hatch and the `bench_internal_test.go` benchmark exception, so this doesn't recur.

## Test plan
- [x] `go test -race ./...` — all pass
- [x] `go tool cover` confirms `parseFieldTag` at 100%
- [x] `gofmt -s -l` clean, `go vet ./...` clean

Fixes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how tag grammar treats lone option tokens (tokens without an `=` are silently ignored, behaving like a simple name tag).
  * Updated contributor guidance with “Test the public contract, not internals,” encouraging validation via public APIs rather than internal implementation details.
* **Bug Fixes**
  * Improved tag option parsing to consistently ignore any token lacking an `=` (including blank pieces), aligning runtime behavior with the documented tag grammar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->