### PR TITLE
docs: note link-time dead-code elimination in Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ name, ok := regextra.FindNamed(re, "Alice 30", "name")  // "Alice", true
 - ✅ **Struct unmarshaling** - Type-safe extraction with automatic conversion
 - ✅ **Safe by default** - Built-in nil checks, returns empty values on no match
 - ✅ **Zero dependencies** - Only depends on Go's standard library
+- ✅ **Pay for what you use** - Unused functions are dead-code-eliminated at link time, so importing the package costs nothing for symbols you don't call
 
 ## License
 


### PR DESCRIPTION
## Summary
- Adds a **Pay for what you use** bullet to the README Features section, recording the single-package packaging rationale settled in #112: unused functions are dead-code-eliminated at link time, so importing the package costs nothing for symbols you don't call.

## Test plan
- [x] Docs-only change — no build/test impact. Verified the Features list renders with the new bullet and parallel phrasing.

Fixes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)