### PR TITLE
feat(unmarshal): support encoding.TextUnmarshaler in field conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ if err := regextra.Validate(re, "name", "age", "ssn"); err != nil {
 
 Unmarshal regex matches into a struct with automatic type conversion. Similar to `json.Unmarshal`, but for regex patterns.
 
-**Supported field types:** `string`, `int`, `int8`, `int16`, `int32`, `int64`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `float32`, `float64`, `bool`, `time.Time`, `time.Duration`. Pointer-to-any-of-the-above is also supported — nil pointers are allocated, non-nil pointers are reused (pointee overwritten). For `time.Time`, several common layouts are tried (RFC3339, RFC3339Nano, `2006-01-02 15:04:05`, `2006-01-02`, `15:04:05`); `time.Duration` is parsed via `time.ParseDuration`. For caller-defined types, implement [`RegexUnmarshaler`](#regexunmarshaler-interface).
+**Supported field types:** `string`, `int`, `int8`, `int16`, `int32`, `int64`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `float32`, `float64`, `bool`, `time.Time`, `time.Duration`. Pointer-to-any-of-the-above is also supported — nil pointers are allocated, non-nil pointers are reused (pointee overwritten). For `time.Time`, several common layouts are tried (RFC3339, RFC3339Nano, `2006-01-02 15:04:05`, `2006-01-02`, `15:04:05`); `time.Duration` is parsed via `time.ParseDuration`. Any field whose type (or pointer-to-type) implements [`encoding.TextUnmarshaler`](https://pkg.go.dev/encoding#TextUnmarshaler) is also supported out of the box — e.g. `netip.Addr`, `math/big.Int`, `log/slog.Level`, `github.com/google/uuid.UUID` — by calling its `UnmarshalText` with the matched value. For caller-defined types, implement [`RegexUnmarshaler`](#regexunmarshaler-interface).
 
 **Field mapping priority:**
 1. Struct tag `regex:"groupname"` if provided (highest priority)
@@ -238,6 +238,8 @@ type RegexUnmarshaler interface {
 ```
 
 The extension point for caller-defined types the built-in type switch can't handle (URLs, enums, big numbers, IP addresses, etc.).
+
+**Conversion precedence.** For each field, `Unmarshal` tries in order: (1) `RegexUnmarshaler` — the package-specific hook always wins; (2) the `time.Time` / `time.Duration` special-cases (so the multi-layout fallback and `layout` tag option are preserved — `time.Time` happens to implement `encoding.TextUnmarshaler` but its `UnmarshalText` only accepts RFC3339, so it is *not* routed through the fallback); (3) `encoding.TextUnmarshaler` — for any other type that implements it; (4) the built-in string/int/uint/float/bool conversion. So a type implementing both `RegexUnmarshaler` and `encoding.TextUnmarshaler` dispatches on `UnmarshalRegex`.
 
 ```go
 type Status int

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -1,6 +1,7 @@
 package regextra
 
 import (
+	"encoding"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -359,6 +360,12 @@ type RegexUnmarshaler interface {
 // the implements-check on every field doesn't pay the reflect.TypeOf cost.
 var regexUnmarshalerType = reflect.TypeOf((*RegexUnmarshaler)(nil)).Elem()
 
+// textUnmarshalerType is the reflect.Type of encoding.TextUnmarshaler, cached
+// for the same reason as regexUnmarshalerType. Many stdlib and third-party
+// types (netip.Addr, big.Int, slog.Level, uuid.UUID, ...) already implement
+// it, so honoring it lets those drop into a struct field with no wrapper.
+var textUnmarshalerType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+
 // setFieldValue sets the field value with appropriate type conversion.
 // `opts` carries per-field tag options parsed from `regex:"name,key=value,..."`.
 // Currently consulted: `layout` (for time.Time fields). Pass nil for no opts.
@@ -435,6 +442,32 @@ func setFieldValue(field reflect.Value, value string, opts map[string]string) er
 		}
 		field.Set(reflect.ValueOf(d))
 		return nil
+	}
+
+	// 3. encoding.TextUnmarshaler fallback. Ranks below RegexUnmarshaler (the
+	//    package-specific extension point keeps priority) AND below the
+	//    time.Time/time.Duration special-cases above: time.Time itself
+	//    satisfies TextUnmarshaler but its UnmarshalText only accepts RFC3339,
+	//    so checking it earlier would silently drop the multi-layout parseTime
+	//    fallback and the `layout` tag option. Mirrors the RegexUnmarshaler
+	//    dispatch: addressable fields via Addr(), interface-typed fields via
+	//    Implements. Pointer fields are handled in step 0 (recurse into Elem,
+	//    where the pointee is addressable and caught here).
+	if field.CanAddr() {
+		if u, ok := field.Addr().Interface().(encoding.TextUnmarshaler); ok {
+			if err := u.UnmarshalText([]byte(value)); err != nil {
+				return fmt.Errorf("cannot convert %q to %s: %w", value, field.Type(), err)
+			}
+			return nil
+		}
+	}
+	if field.Type().Implements(textUnmarshalerType) {
+		if u, ok := field.Interface().(encoding.TextUnmarshaler); ok {
+			if err := u.UnmarshalText([]byte(value)); err != nil {
+				return fmt.Errorf("cannot convert %q to %s: %w", value, field.Type(), err)
+			}
+			return nil
+		}
 	}
 
 	switch field.Kind() {

--- a/unmarshal_textunmarshaler_test.go
+++ b/unmarshal_textunmarshaler_test.go
@@ -2,6 +2,7 @@ package regextra_test
 
 import (
 	"encoding"
+	"fmt"
 	"math/big"
 	"net/netip"
 	"regexp"
@@ -18,6 +19,20 @@ import (
 // Fixtures are stdlib-only (no new module dependency): netip.Addr, math/big.Int
 // (pointer receiver), and log/slog.Level (underlying int, must NOT be routed
 // through the built-in int conversion).
+
+// ExampleUnmarshal_textUnmarshaler shows that any field type implementing
+// encoding.TextUnmarshaler (here the stdlib's netip.Addr) is populated from its
+// capture group via UnmarshalText, with no regextra-specific code required.
+func ExampleUnmarshal_textUnmarshaler() {
+	type Conn struct {
+		Addr netip.Addr `regex:"addr"`
+	}
+	re := regexp.MustCompile(`from (?P<addr>\S+)`)
+	var c Conn
+	_ = rx.Unmarshal(re, "from 192.168.0.1", &c)
+	fmt.Println(c.Addr)
+	// Output: 192.168.0.1
+}
 
 func TestUnmarshal_TextUnmarshaler_Value(t *testing.T) {
 	type rec struct {

--- a/unmarshal_textunmarshaler_test.go
+++ b/unmarshal_textunmarshaler_test.go
@@ -1,0 +1,164 @@
+package regextra_test
+
+import (
+	"encoding"
+	"math/big"
+	"net/netip"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"log/slog"
+
+	rx "github.com/jecoms/regextra"
+)
+
+// These tests lock in the encoding.TextUnmarshaler fallback added for #119.
+// Fixtures are stdlib-only (no new module dependency): netip.Addr, math/big.Int
+// (pointer receiver), and log/slog.Level (underlying int, must NOT be routed
+// through the built-in int conversion).
+
+func TestUnmarshal_TextUnmarshaler_Value(t *testing.T) {
+	type rec struct {
+		Addr  netip.Addr `regex:"addr"`
+		Big   big.Int    `regex:"big"`
+		Level slog.Level `regex:"level"`
+	}
+
+	re := regexp.MustCompile(`(?P<addr>\S+) (?P<big>\S+) (?P<level>\S+)`)
+	var got rec
+	if err := rx.Unmarshal(re, "192.168.0.1 123456789012345678901234567890 WARN", &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if want := netip.MustParseAddr("192.168.0.1"); got.Addr != want {
+		t.Errorf("Addr = %v, want %v", got.Addr, want)
+	}
+	wantBig, _ := new(big.Int).SetString("123456789012345678901234567890", 10)
+	if got.Big.Cmp(wantBig) != 0 {
+		t.Errorf("Big = %v, want %v", &got.Big, wantBig)
+	}
+	if got.Level != slog.LevelWarn {
+		t.Errorf("Level = %v, want %v", got.Level, slog.LevelWarn)
+	}
+}
+
+func TestUnmarshal_TextUnmarshaler_Pointer(t *testing.T) {
+	type rec struct {
+		Addr  *netip.Addr `regex:"addr"`
+		Big   *big.Int    `regex:"big"`
+		Level *slog.Level `regex:"level"`
+	}
+
+	re := regexp.MustCompile(`(?P<addr>\S+) (?P<big>\S+) (?P<level>\S+)`)
+	var got rec
+	if err := rx.Unmarshal(re, "::1 42 ERROR", &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if got.Addr == nil || *got.Addr != netip.MustParseAddr("::1") {
+		t.Errorf("Addr = %v, want ::1", got.Addr)
+	}
+	if got.Big == nil || got.Big.Int64() != 42 {
+		t.Errorf("Big = %v, want 42", got.Big)
+	}
+	if got.Level == nil || *got.Level != slog.LevelError {
+		t.Errorf("Level = %v, want ERROR", got.Level)
+	}
+}
+
+func TestUnmarshal_TextUnmarshaler_InterfaceField(t *testing.T) {
+	// An interface-typed field pre-populated with a concrete implementation is
+	// dispatched via Type().Implements, mirroring the RegexUnmarshaler path.
+	type rec struct {
+		Addr encoding.TextUnmarshaler `regex:"addr"`
+	}
+
+	re := regexp.MustCompile(`(?P<addr>\S+)`)
+	var ip netip.Addr
+	got := rec{Addr: &ip}
+	if err := rx.Unmarshal(re, "10.0.0.7", &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if want := netip.MustParseAddr("10.0.0.7"); ip != want {
+		t.Errorf("Addr = %v, want %v", ip, want)
+	}
+}
+
+func TestUnmarshal_TextUnmarshaler_Error(t *testing.T) {
+	type rec struct {
+		Addr netip.Addr `regex:"addr"`
+	}
+
+	re := regexp.MustCompile(`(?P<addr>\S+)`)
+	var got rec
+	err := rx.Unmarshal(re, "not-an-ip", &got)
+	if err == nil {
+		t.Fatal("expected error for invalid netip.Addr, got nil")
+	}
+	if !strings.Contains(err.Error(), "not-an-ip") {
+		t.Errorf("error %q should mention the offending value", err)
+	}
+}
+
+// regexAndText implements BOTH RegexUnmarshaler and encoding.TextUnmarshaler;
+// RegexUnmarshaler must win.
+type regexAndText struct {
+	via string
+}
+
+func (r *regexAndText) UnmarshalRegex(value string) error {
+	r.via = "regex:" + value
+	return nil
+}
+
+func (r *regexAndText) UnmarshalText(text []byte) error {
+	r.via = "text:" + string(text)
+	return nil
+}
+
+func TestUnmarshal_RegexUnmarshaler_BeatsTextUnmarshaler(t *testing.T) {
+	type rec struct {
+		F regexAndText `regex:"f"`
+	}
+	re := regexp.MustCompile(`(?P<f>\S+)`)
+	var got rec
+	if err := rx.Unmarshal(re, "hello", &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.F.via != "regex:hello" {
+		t.Errorf("dispatched via %q, want RegexUnmarshaler", got.F.via)
+	}
+}
+
+// TestUnmarshal_TimeBeatsTextUnmarshaler locks the ordering: time.Time itself
+// satisfies encoding.TextUnmarshaler with an RFC3339-only UnmarshalText. If the
+// TextUnmarshaler check ran before the time special-case, the multi-layout
+// fallback and the `layout` tag option below would be dropped and these
+// non-RFC3339 inputs would fail to parse.
+func TestUnmarshal_TimeBeatsTextUnmarshaler(t *testing.T) {
+	type fallback struct {
+		TS time.Time `regex:"ts"`
+	}
+	re := regexp.MustCompile(`(?P<ts>.+)`)
+	var got fallback
+	if err := rx.Unmarshal(re, "2024-01-15", &got); err != nil {
+		t.Fatalf("Unmarshal (fallback list): %v", err)
+	}
+	if got.TS.Year() != 2024 || got.TS.Month() != time.January || got.TS.Day() != 15 {
+		t.Errorf("TS = %v, want 2024-01-15", got.TS)
+	}
+
+	type withLayout struct {
+		TS time.Time `regex:"ts,layout=02/Jan/2006"`
+	}
+	reL := regexp.MustCompile(`(?P<ts>.+)`)
+	var gotL withLayout
+	if err := rx.Unmarshal(reL, "15/Jan/2024", &gotL); err != nil {
+		t.Fatalf("Unmarshal (layout opt): %v", err)
+	}
+	if gotL.TS.Year() != 2024 || gotL.TS.Month() != time.January || gotL.TS.Day() != 15 {
+		t.Errorf("TS = %v, want 2024-01-15 via layout", gotL.TS)
+	}
+}


### PR DESCRIPTION
## Summary
- Add an `encoding.TextUnmarshaler` fallback to `setFieldValue`, so any field whose type (or pointer-to-type) implements it — `netip.Addr`, `math/big.Int`, `log/slog.Level`, `uuid.UUID`, etc. — unmarshals with no `RegexUnmarshaler` wrapper.
- Precedence: `RegexUnmarshaler` > `time.Time`/`time.Duration` special-case > `TextUnmarshaler` > built-in Kind switch. The new check deliberately sits **after** the time special-case: `time.Time` satisfies `TextUnmarshaler` with an RFC3339-only `UnmarshalText`, so an earlier check would silently drop the multi-layout `parseTime` fallback and the `layout` tag option.
- Dispatch mirrors the existing `RegexUnmarshaler` trio (addressable `Addr()` + interface-typed `Implements`). Updated dispatch-order comments and README (supported-types note + `RegexUnmarshaler` precedence note). Non-breaking per the existing SemVer policy.

## Test plan
- [x] `go test -race ./...` — pass (new `unmarshal_textunmarshaler_test.go`: value & pointer fields, interface-typed field, error path, `RegexUnmarshaler`-beats-`TextUnmarshaler`, and a `time.Time` regression locking the ordering via a non-RFC3339 layout + fallback list)
- [x] `go vet ./...` — clean
- [x] `gofmt -s -l .` — clean
- [x] `golangci-lint run` — 0 issues
- [x] Coverage 96.8% (gate 92%); new branch incl. error path and interface-typed case exercised

Fixes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)