### PR TITLE
feat: add ReplaceFunc for callback-based named-group replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ out := regextra.Replace(re, "alice@example.com bob@other.org", map[string]string
 // out = "alice@redacted bob@redacted"
 ```
 
+### `ReplaceFunc(re *regexp.Regexp, target string, fn func(group, match string) string) string`
+
+Like `Replace`, but the replacement for each named-group span is computed by a callback over the matched value instead of looked up in a static map. Use it when the substitution depends on what matched — redaction, normalization, and similar. `fn` is called once per substituted named span, left to right, with the group's name and matched text; return the match verbatim to leave a group unchanged. On no match the target is returned unchanged and `fn` is never called. Passing a nil `fn` is a programmer error and panics on the first match, mirroring the standard library's `Regexp.ReplaceAllStringFunc`.
+
+When named groups overlap (nesting), the outermost group whose span is encountered first wins and `fn` is not called for inner groups inside an already-substituted span — the same overlap rule as `Replace`.
+
+```go
+// Mask all but the last four digits of a captured card number:
+re := regexp.MustCompile(`(?P<card>\d{12,19})`)
+out := regextra.ReplaceFunc(re, "card 4111111111111111 ok", func(group, match string) string {
+    return strings.Repeat("*", len(match)-4) + match[len(match)-4:]
+})
+// out = "card ************1111 ok"
+```
+
 ### `Validate(re *regexp.Regexp, required ...string) error`
 
 Returns an error listing every required group name that is not declared on `re`. Use it for init-time assertions in services that compile patterns once: catch typos at startup rather than at the first (mis-)matched request.

--- a/regextra.go
+++ b/regextra.go
@@ -43,6 +43,7 @@ By use case:
   - Pull every named group from one match, keeping every value when a group
     name is reused inside the pattern (map of slices): [AllNamedGroups]
   - Substitute named-group spans by name: [Replace]
+  - Substitute named-group spans with a callback over the matched value: [ReplaceFunc]
   - Assert at startup that required groups are declared: [Validate]
   - Decode one match into a struct: [Unmarshal]
   - Decode all matches into a slice of structs: [UnmarshalAll]
@@ -73,6 +74,8 @@ the no-match form that lets the caller continue without a special-case branch.
 	                                          name is not declared on the regex)
 	NamedGroups, AllNamedGroups               empty map (initialized, not nil)
 	Replace                                   target returned unchanged
+	ReplaceFunc                               target returned unchanged (fn
+	                                          never called)
 	Validate                                  unrelated — checks declarations,
 	                                          not matches against a target
 	Unmarshal                                 nil error; destination struct left
@@ -424,6 +427,57 @@ func Replace(re *regexp.Regexp, target string, replacements map[string]string) s
 	if len(replacements) == 0 {
 		return target
 	}
+	return replaceNamed(re, target, func(name, _ string) (string, bool) {
+		repl, ok := replacements[name]
+		return repl, ok
+	})
+}
+
+// ReplaceFunc substitutes the matched span of each named capture group in
+// target with the string returned by fn, which is called with the group's name
+// and the text it matched. Like [Replace] it operates on every match of re, in
+// order — but the replacement is computed from the matched value rather than
+// looked up in a static map. Use it for substitutions that depend on what
+// matched: redaction (mask all but the last four digits of a card number),
+// normalization (lowercase a captured host), and similar.
+//
+// fn runs once per substituted named span, left to right. To leave a group
+// unchanged, return its match verbatim. This differs from [Replace], which
+// passes a group through when it is absent from the map: every participating
+// named group reaches fn, so fn itself decides what to keep. Passing a nil fn
+// is a programmer error — it panics on the first match, mirroring the standard
+// library's [regexp.Regexp.ReplaceAllStringFunc].
+//
+// When named groups overlap (nesting), the outermost named group whose span is
+// encountered first wins; fn is not called for inner groups inside an
+// already-substituted span — matching [Replace]'s overlap rule.
+//
+// On no match, returns target unchanged and never calls fn. See the package
+// doc's "No-match behavior" section for the full cross-API contract.
+//
+// Example — mask all but the last four digits of a captured card number:
+//
+//	re := regexp.MustCompile(`(?P<card>\d{12,19})`)
+//	out := regextra.ReplaceFunc(re, "card 4111111111111111 ok", func(group, match string) string {
+//	    return strings.Repeat("*", len(match)-4) + match[len(match)-4:]
+//	})
+//	// out = "card ************1111 ok"
+func ReplaceFunc(re *regexp.Regexp, target string, fn func(group, match string) string) string {
+	return replaceNamed(re, target, func(name, matched string) (string, bool) {
+		return fn(name, matched), true
+	})
+}
+
+// replaceNamed is the shared substitution engine behind [Replace] and
+// [ReplaceFunc]. It walks every match of re over target and, for each
+// participating named group, asks replFor for the replacement; replFor reports
+// false to pass the group's matched text through unchanged.
+//
+// replFor is resolved at apply time and only for spans that actually win the
+// overlap rule, so a group skipped by an enclosing outermost span never reaches
+// it — [ReplaceFunc] therefore never invokes its callback for an inner group it
+// suppresses, and [Replace] does its map lookup only where it matters.
+func replaceNamed(re *regexp.Regexp, target string, replFor func(name, matched string) (string, bool)) string {
 	matches := re.FindAllStringSubmatchIndex(target, -1)
 	if len(matches) == 0 {
 		return target
@@ -432,7 +486,7 @@ func Replace(re *regexp.Regexp, target string, replacements map[string]string) s
 
 	type span struct {
 		start, end int
-		repl       string
+		name       string
 	}
 
 	var b strings.Builder
@@ -445,15 +499,11 @@ func Replace(re *regexp.Regexp, target string, replacements map[string]string) s
 			if name == "" {
 				continue
 			}
-			repl, ok := replacements[name]
-			if !ok {
-				continue
-			}
 			s, e := m[2*i], m[2*i+1]
 			if s < 0 || e < 0 {
 				continue
 			}
-			spans = append(spans, span{start: s, end: e, repl: repl})
+			spans = append(spans, span{start: s, end: e, name: name})
 		}
 		// Sort by start ascending, then end descending: when named groups share
 		// a start offset (nested groups), the outermost span — the one with the
@@ -472,8 +522,12 @@ func Replace(re *regexp.Regexp, target string, replacements map[string]string) s
 			if sp.start < cursor {
 				continue // already covered (overlap with an earlier substitution)
 			}
+			repl, ok := replFor(sp.name, target[sp.start:sp.end])
+			if !ok {
+				continue // group passes through unchanged; cursor not advanced
+			}
 			b.WriteString(target[cursor:sp.start])
-			b.WriteString(sp.repl)
+			b.WriteString(repl)
 			cursor = sp.end
 		}
 	}

--- a/regextra_bench_test.go
+++ b/regextra_bench_test.go
@@ -288,6 +288,35 @@ func BenchmarkReplace(b *testing.B) {
 	benchCase(b, "longReplacement", func() { sinkStr = rx.Replace(bnRepEmailRe, bnRepMulti100In, bnRepLongMap) }) // Builder growth
 }
 
+// ── ReplaceFunc ─────────────────────────────────────────────────────────────
+//
+// Same span engine as Replace, but the replacement is computed per applied span
+// by a caller callback over the matched value rather than a map lookup. Cost
+// dimensions mirror Replace (match count, groups-per-match sort size); the extra
+// axis is callback cost — bnRepFuncIdentity returns the match verbatim to isolate
+// dispatch overhead, bnRepFuncUpper does real per-span work.
+
+var (
+	bnRepFuncIdentity = func(_, m string) string { return m }
+	bnRepFuncUpper    = func(_, m string) string { return strings.ToUpper(m) }
+)
+
+func BenchmarkReplaceFunc(b *testing.B) {
+	// representative — one match, then a realistic 100-match batch.
+	benchCase(b, "singleGroup", func() { sinkStr = rx.ReplaceFunc(bnRepEmailRe, bnRepSingleIn, bnRepFuncUpper) })
+	benchCase(b, "matches100", func() { sinkStr = rx.ReplaceFunc(bnRepEmailRe, bnRepMulti100In, bnRepFuncUpper) })
+	// edge — no match takes the early return; fn is never called.
+	benchCase(b, "noMatch", func() { sinkStr = rx.ReplaceFunc(bnRepEmailRe, bnRepNoMatchIn, bnRepFuncUpper) })
+	// dispatch-only — identity callback isolates closure/indirection cost.
+	benchCase(b, "identity", func() { sinkStr = rx.ReplaceFunc(bnRepEmailRe, bnRepMulti100In, bnRepFuncIdentity) })
+	// pathological — overlap (outermost wins, inner fn suppressed) and optional skip.
+	benchCase(b, "nestedGroups", func() { sinkStr = rx.ReplaceFunc(bnRepNestRe, bnRepSingleIn, bnRepFuncUpper) })
+	benchCase(b, "optionalNonParticipating", func() { sinkStr = rx.ReplaceFunc(bnRepOptRe, bnRepOptIn, bnRepFuncUpper) })
+	// scaling — sort size per match and match count.
+	benchCase(b, "manyGroupsPerMatch", func() { sinkStr = rx.ReplaceFunc(bnRepManyGRe, bnRepManyGIn, bnRepFuncUpper) })
+	benchCase(b, "largeManyMatches", func() { sinkStr = rx.ReplaceFunc(bnRepEmailRe, bnRepMulti1200In, bnRepFuncUpper) })
+}
+
 // ── Validate ──────────────────────────────────────────────────────────────────
 //
 // Cost model: build a set of declared names from SubexpNames (scales with

--- a/regextra_test.go
+++ b/regextra_test.go
@@ -5,6 +5,7 @@ import (
 	rx "github.com/jecoms/regextra"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -391,6 +392,149 @@ func ExampleReplace() {
 	})
 	fmt.Println(out)
 	// Output: alice@redacted bob@redacted
+}
+
+func TestReplaceFunc(t *testing.T) {
+	upper := func(_, m string) string { return strings.ToUpper(m) }
+
+	tests := []struct {
+		name    string
+		pattern string
+		target  string
+		fn      func(group, match string) string
+		want    string
+	}{
+		{
+			name:    "redaction: mask all but last four digits",
+			pattern: `(?P<card>\d{12,19})`,
+			target:  "card 4111111111111111 ok",
+			fn: func(_, m string) string {
+				return strings.Repeat("*", len(m)-4) + m[len(m)-4:]
+			},
+			want: "card ************1111 ok",
+		},
+		{
+			name:    "normalization: lowercase captured host across matches",
+			pattern: `https?://(?P<host>[\w.]+)`,
+			target:  "http://Example.COM and https://API.Example.com",
+			fn:      func(_, m string) string { return strings.ToLower(m) },
+			want:    "http://example.com and https://api.example.com",
+		},
+		{
+			name:    "fn receives the group name",
+			pattern: `(?P<key>\w+)=(?P<val>\d+)`,
+			target:  "a=1 b=2",
+			fn:      func(group, m string) string { return group + ":" + m },
+			want:    "key:a=val:1 key:b=val:2",
+		},
+		{
+			name:    "return match verbatim leaves the group unchanged",
+			pattern: `(?P<user>\w+)@(?P<domain>[\w.]+)`,
+			target:  "alice@example.com",
+			fn: func(group, m string) string {
+				if group == "domain" {
+					return "redacted"
+				}
+				return m // leave user unchanged
+			},
+			want: "alice@redacted",
+		},
+		{
+			name:    "no match returns target unchanged",
+			pattern: `(?P<word>[A-Z]+)`,
+			target:  "no matches here",
+			fn:      upper,
+			want:    "no matches here",
+		},
+		{
+			name:    "preserves non-matching text between matches",
+			pattern: `(?P<num>\d+)`,
+			target:  "a 1 b 2 c 3 d",
+			fn:      func(_, m string) string { return "<" + m + ">" },
+			want:    "a <1> b <2> c <3> d",
+		},
+		{
+			// Inner group inside an already-substituted outermost span is not
+			// reached by fn — mirrors Replace's overlap rule.
+			name:    "nested groups, outermost wins and inner fn not invoked",
+			pattern: `(?P<outer>(?P<inner>\w+)@[\w.]+)`,
+			target:  "alice@example.com",
+			fn:      upper,
+			want:    "ALICE@EXAMPLE.COM",
+		},
+		{
+			// Non-participating optional group is skipped, so fn never sees it.
+			name:    "optional non-participating group skipped",
+			pattern: `(?P<word>\w+)(?P<bang>!)?`,
+			target:  "hi there",
+			fn:      func(_, m string) string { return "[" + m + "]" },
+			want:    "[hi] [there]",
+		},
+		{
+			// Duplicate group name: fn runs for each participating occurrence.
+			name:    "duplicate group name, fn runs per occurrence",
+			pattern: `(?P<w>\w+) (?P<w>\w+)`,
+			target:  "hello world",
+			fn:      upper,
+			want:    "HELLO WORLD",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			re := regexp.MustCompile(tt.pattern)
+			got := rx.ReplaceFunc(re, tt.target, tt.fn)
+			if got != tt.want {
+				t.Errorf("ReplaceFunc = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReplaceFuncInnerGroupNotInvoked(t *testing.T) {
+	// fn must never be called for an inner group suppressed by an outermost
+	// span — assert the callback is not invoked for the "inner" name.
+	re := regexp.MustCompile(`(?P<outer>(?P<inner>\w+)@[\w.]+)`)
+	var seen []string
+	out := rx.ReplaceFunc(re, "alice@example.com", func(group, m string) string {
+		seen = append(seen, group)
+		return strings.ToUpper(m)
+	})
+	if out != "ALICE@EXAMPLE.COM" {
+		t.Errorf("ReplaceFunc = %q, want %q", out, "ALICE@EXAMPLE.COM")
+	}
+	for _, g := range seen {
+		if g == "inner" {
+			t.Errorf("fn invoked for suppressed inner group; groups seen = %v", seen)
+		}
+	}
+	if len(seen) != 1 || seen[0] != "outer" {
+		t.Errorf("groups seen = %v, want [outer]", seen)
+	}
+}
+
+func TestReplaceFuncNoMatchNeverCallsFn(t *testing.T) {
+	re := regexp.MustCompile(`(?P<word>[A-Z]+)`)
+	called := false
+	out := rx.ReplaceFunc(re, "no matches here", func(_, m string) string {
+		called = true
+		return m
+	})
+	if called {
+		t.Error("fn was called despite no match")
+	}
+	if out != "no matches here" {
+		t.Errorf("ReplaceFunc = %q, want target unchanged", out)
+	}
+}
+
+func ExampleReplaceFunc() {
+	// Mask all but the last four digits of a captured card number.
+	re := regexp.MustCompile(`(?P<card>\d{12,19})`)
+	out := rx.ReplaceFunc(re, "card 4111111111111111 ok", func(_, match string) string {
+		return strings.Repeat("*", len(match)-4) + match[len(match)-4:]
+	})
+	fmt.Println(out)
+	// Output: card ************1111 ok
 }
 
 func TestValidate(t *testing.T) {

--- a/regextra_test.go
+++ b/regextra_test.go
@@ -527,6 +527,33 @@ func TestReplaceFuncNoMatchNeverCallsFn(t *testing.T) {
 	}
 }
 
+func TestReplaceFuncNilFn(t *testing.T) {
+	// A nil fn is a programmer error. It panics on the first substituted match,
+	// mirroring regexp.Regexp.ReplaceAllStringFunc, but never panics when there
+	// is nothing to substitute (no match returns target before fn is reached).
+	t.Run("panics on first match", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Error("ReplaceFunc with nil fn did not panic on a match")
+			}
+		}()
+		re := regexp.MustCompile(`(?P<word>[A-Z]+)`)
+		rx.ReplaceFunc(re, "HELLO", nil)
+	})
+
+	t.Run("no panic on no match", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("ReplaceFunc with nil fn panicked on no match: %v", r)
+			}
+		}()
+		re := regexp.MustCompile(`(?P<word>[A-Z]+)`)
+		if out := rx.ReplaceFunc(re, "no matches here", nil); out != "no matches here" {
+			t.Errorf("ReplaceFunc = %q, want target unchanged", out)
+		}
+	})
+}
+
 func ExampleReplaceFunc() {
 	// Mask all but the last four digits of a captured card number.
 	re := regexp.MustCompile(`(?P<card>\d{12,19})`)


### PR DESCRIPTION
## Summary
- Add `ReplaceFunc(re, target, fn func(group, match string) string)` — a callback analogue of `Replace` whose substitution depends on the matched value (redaction, normalization), filling the gap left by `Replace`'s static `map[string]string`.
- Extract the span collect → stable-sort (start asc, end desc) → outermost-wins apply loop into a shared unexported `replaceNamed` helper; `Replace` and `ReplaceFunc` are now thin wrappers and both inherit the #107 stable-sort tie-break.
- Resolve the replacement at apply time, so `fn` is never invoked for an inner group suppressed by an enclosing outermost span. `Replace`'s map lookup moves to the same point (behavior-equivalent).
- Docs: godoc on `ReplaceFunc`/`replaceNamed`, package-doc "API at a glance" + "No-match behavior" table entries, and a README section after `Replace`.

Contract notes (per the issue's implementation plan): every participating named group reaches `fn`; return the match verbatim to leave a group unchanged. On no match the target is returned unchanged and `fn` is never called. A nil `fn` is a programmer error and panics on the first match, mirroring stdlib `Regexp.ReplaceAllStringFunc`.

## Test plan
- [x] `go test -race ./...` — all pass (table-driven `TestReplaceFunc` covering redaction, normalization, group-name passthrough, no-match, non-matching-text preservation, nested/overlap, optional non-participating, duplicate names; plus targeted tests that `fn` is not invoked for a suppressed inner group and never called on no match; `ExampleReplaceFunc`).
- [x] `go vet ./...`, `gofmt -s -l .`, `golangci-lint run` — clean.
- [x] `go test -bench BenchmarkReplace -benchmem` — added `BenchmarkReplaceFunc`; existing `Replace` benchmarks remain in line after the refactor.

Fixes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)