### PR TITLE
feat: add NamedGroupsPerMatch and NamedGroupsPerMatchSeq (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`NamedGroupsPerMatch(re *regexp.Regexp, target string) []map[string]string`** and **`NamedGroupsPerMatchSeq(re *regexp.Regexp, target string) iter.Seq[map[string]string]`** — the every-match counterparts to `NamedGroups`, returning one named-group map per match (slice form) or yielding them lazily (range-over-func form). Each per-match map follows `NamedGroups` semantics: every declared group present, non-participating groups mapped to `""`, and reused names resolved to the last participating occurrence in that match. Fills the gap the `AllNamedGroups` godoc previously disclaimed ("no current function that returns every named group across every match"). Names deliberately avoid the overloaded "All" token. Additive, non-breaking. ([#118](https://github.com/Jecoms/regextra/issues/118))
+
 ### Fixed
 
 - **`regex:"-"` now excludes a field instead of falling back to field-name matching. (Breaking.)** Previously `parseFieldTag` collapsed `regex:"-"` and `regex:""` to the same "no name" result, so a field tagged `regex:"-"` would still be populated if a declared group happened to share the field's name — the opposite of the `-` convention in `encoding/json`, `encoding/xml`, and `gopkg.in/yaml`. Now the bare `-` tag excludes the field entirely from both `Unmarshal`/`UnmarshalAll` and `Decoder`. `Decoder` and `UnmarshalAll` build a fresh result, so the field is left at its zero value; `Unmarshal` writes into the caller's struct in place and never resets it, so the field keeps whatever it already held (the zero value for a freshly declared struct). An absent tag (`regex:""`) still falls back to the field's own name as before. Only the bare `-` excludes; a leading `-` followed by options (e.g. `regex:"-,default=x"`) still parses `-` as the group name. **Observable behavior change:** a field tagged `regex:"-"` whose name matches a group is no longer populated. ([#106](https://github.com/Jecoms/regextra/issues/106))

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ groups := regextra.NamedGroups(re, "Date: 2025-10-04")
 
 Operates on a **single match** and returns every value of every named capture group, keyed by group name. Each value is a slice because Go's `regexp` allows the same group name to appear more than once in a pattern — `AllNamedGroups` preserves every occurrence in left-to-right order. Groups that appear once still get a one-element slice.
 
-The leading "All" refers to **all named groups in one match** — not to all matches across the target. Use `FindAllNamed` to collect a single named group across every match. There is currently no function that returns every named group across every match (`[]map[string]string`); the unmarshal path (`UnmarshalAll`, `Decoder.All`, `Decoder.Iter`) is the typed equivalent.
+The leading "All" refers to **all named groups in one match** — not to all matches across the target. Use `FindAllNamed` to collect a single named group across every match, or `NamedGroupsPerMatch` to collect every named group across every match as one map per match (`[]map[string]string`); the unmarshal path (`UnmarshalAll`, `Decoder.All`, `Decoder.Iter`) is the typed equivalent.
 
 Returns an empty map if no match is found.
 
@@ -136,6 +136,31 @@ allGroups := regextra.AllNamedGroups(re, "one two three")
 re = regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
 allGroups = regextra.AllNamedGroups(re, "Alice 30")
 // allGroups = map[string][]string{"name": []string{"Alice"}, "age": []string{"30"}}
+```
+
+### `NamedGroupsPerMatch(re *regexp.Regexp, target string) []map[string]string`
+
+The every-match counterpart to `NamedGroups`: returns one map of named-group values per match of `re` in `target`, in match order. Each map follows the same per-match semantics as `NamedGroups` — every declared group is present, a group that did not participate in that match is mapped to `""`, and a reused group name resolves to the last participating occurrence in that match.
+
+Returns an empty (non-nil) slice if there are no matches. For the typed equivalent that decodes each match into a struct, use `UnmarshalAll` / `Decoder.All`.
+
+```go
+re := regexp.MustCompile(`(?P<key>\w+)=(?P<value>\w+)`)
+all := regextra.NamedGroupsPerMatch(re, "a=1 b=2")
+// all = []map[string]string{{"key": "a", "value": "1"}, {"key": "b", "value": "2"}}
+```
+
+### `NamedGroupsPerMatchSeq(re *regexp.Regexp, target string) iter.Seq[map[string]string]`
+
+The lazy, range-over-func (Go 1.23+) form of `NamedGroupsPerMatch`: yields one named-group map per match, in match order, without building the intermediate slice. Stopping the range early (`break`) stops the iteration. On no match, the iterator yields zero times. For the typed streaming equivalent, use `Decoder.Iter`.
+
+```go
+re := regexp.MustCompile(`(?P<key>\w+)=(?P<value>\w+)`)
+for m := range regextra.NamedGroupsPerMatchSeq(re, "a=1 b=2") {
+    fmt.Println(m["key"], m["value"])
+}
+// a 1
+// b 2
 ```
 
 ### `Replace(re *regexp.Regexp, target string, replacements map[string]string) string`

--- a/regextra.go
+++ b/regextra.go
@@ -42,6 +42,8 @@ By use case:
   - Pull every named group from one match (map): [NamedGroups]
   - Pull every named group from one match, keeping every value when a group
     name is reused inside the pattern (map of slices): [AllNamedGroups]
+  - Pull every named group across all matches (one map per match):
+    [NamedGroupsPerMatch], or lazily [NamedGroupsPerMatchSeq]
   - Substitute named-group spans by name: [Replace]
   - Assert at startup that required groups are declared: [Validate]
   - Decode one match into a struct: [Unmarshal]
@@ -72,6 +74,8 @@ the no-match form that lets the caller continue without a special-case branch.
 	FindAllNamed                              []string{} (or nil if the group
 	                                          name is not declared on the regex)
 	NamedGroups, AllNamedGroups               empty map (initialized, not nil)
+	NamedGroupsPerMatch                       []map[string]string{} (empty, not nil)
+	NamedGroupsPerMatchSeq                    iterator yields zero times
 	Replace                                   target returned unchanged
 	Validate                                  unrelated — checks declarations,
 	                                          not matches against a target
@@ -183,6 +187,7 @@ package regextra
 import (
 	"cmp"
 	"fmt"
+	"iter"
 	"regexp"
 	"slices"
 	"strings"
@@ -305,6 +310,75 @@ func NamedGroups(re *regexp.Regexp, target string) map[string]string {
 	return namedGroupValues(re, target, m, true)
 }
 
+// NamedGroupsPerMatch returns one map of named-group values per match of re in
+// target, in match order — the every-match counterpart to [NamedGroups]. Each
+// map follows the same per-match semantics as [NamedGroups]: every declared
+// group is present, a group that did not participate in that match is mapped to
+// "", and when the pattern reuses a group name the last participating
+// occurrence in that match wins.
+//
+// On no match, returns an empty (non-nil) slice. See the package doc's
+// "No-match behavior" section for the full cross-API contract. For the lazy,
+// allocation-light streaming form, use [NamedGroupsPerMatchSeq]. For the typed
+// equivalent that decodes each match into a struct, use [UnmarshalAll] /
+// [Decoder.All].
+//
+// Example:
+//
+//	re := regexp.MustCompile(`(?P<key>\w+)=(?P<value>\w+)`)
+//	all := regextra.NamedGroupsPerMatch(re, "a=1 b=2")
+//	// all = []map[string]string{{"key": "a", "value": "1"}, {"key": "b", "value": "2"}}
+func NamedGroupsPerMatch(re *regexp.Regexp, target string) []map[string]string {
+	locs := re.FindAllStringSubmatchIndex(target, -1)
+	if len(locs) == 0 {
+		return []map[string]string{}
+	}
+	names := re.SubexpNames()
+	out := make([]map[string]string, len(locs))
+	for i, m := range locs {
+		result := make(map[string]string, len(names))
+		fillNamedGroupValues(result, names, target, m, true)
+		out[i] = result
+	}
+	return out
+}
+
+// NamedGroupsPerMatchSeq is the range-over-func (Go 1.23+) form of
+// [NamedGroupsPerMatch]: it yields one named-group map per match of re in
+// target, in match order, without building the intermediate slice. Each yielded
+// map follows the same per-match semantics as [NamedGroups]. Stopping the range
+// early stops the iteration.
+//
+// On no match, the iterator yields zero times. See the package doc's "No-match
+// behavior" section for the full cross-API contract. For the typed streaming
+// equivalent, use [Decoder.Iter].
+//
+// Example:
+//
+//	re := regexp.MustCompile(`(?P<key>\w+)=(?P<value>\w+)`)
+//	for m := range regextra.NamedGroupsPerMatchSeq(re, "a=1 b=2") {
+//	    fmt.Println(m["key"], m["value"])
+//	}
+//	// Output:
+//	// a 1
+//	// b 2
+func NamedGroupsPerMatchSeq(re *regexp.Regexp, target string) iter.Seq[map[string]string] {
+	return func(yield func(map[string]string) bool) {
+		locs := re.FindAllStringSubmatchIndex(target, -1)
+		if len(locs) == 0 {
+			return
+		}
+		names := re.SubexpNames()
+		for _, m := range locs {
+			result := make(map[string]string, len(names))
+			fillNamedGroupValues(result, names, target, m, true)
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
 // namedGroupValues builds the group-name→value map for one match, given the
 // match's index pairs from FindStringSubmatchIndex (or one element of
 // FindAllStringSubmatchIndex). Index pairs distinguish "did not participate"
@@ -361,10 +435,11 @@ func fillNamedGroupValues(dst map[string]string, names []string, target string, 
 // The leading "All" refers to all named groups in one match — not to all
 // matches across the target. Internally the function calls FindStringSubmatch,
 // so only the first match contributes values. To collect every value of a
-// single named group across every match in the target, use [FindAllNamed].
-// There is no current function that returns every named group across every
-// match (i.e. []map[string]string); the unmarshal path ([UnmarshalAll],
-// [Decoder.All], [Decoder.Iter]) is the typed equivalent.
+// single named group across every match in the target, use [FindAllNamed]. To
+// collect every named group across every match as one map per match, use
+// [NamedGroupsPerMatch] (or [NamedGroupsPerMatchSeq] for the lazy form); the
+// unmarshal path ([UnmarshalAll], [Decoder.All], [Decoder.Iter]) is the typed
+// equivalent.
 //
 // On no match, returns an empty (non-nil) map. See the package doc's
 // "No-match behavior" section for the full cross-API contract.

--- a/regextra_bench_test.go
+++ b/regextra_bench_test.go
@@ -52,13 +52,14 @@ import (
 // One per return kind, assigned in every loop body to defeat dead-store
 // elimination of the benchmarked call's result.
 var (
-	sinkStr   string
-	sinkOK    bool
-	sinkStrs  []string
-	sinkMap   map[string]string
-	sinkMapSS map[string][]string
-	sinkErr   error
-	sinkAny   any
+	sinkStr      string
+	sinkOK       bool
+	sinkStrs     []string
+	sinkMap      map[string]string
+	sinkMapSS    map[string][]string
+	sinkSliceMap []map[string]string
+	sinkErr      error
+	sinkAny      any
 )
 
 // benchCase runs fn in an allocation-reporting b.Loop under a named sub-benchmark.
@@ -234,6 +235,37 @@ func BenchmarkAllNamedGroups(b *testing.B) {
 	benchCase(b, "duplicateGroupName", func() { sinkMapSS = rx.AllNamedGroups(bnANGDupRe, bnANGDupIn) }) // 3 occurrences under one key
 	benchCase(b, "noMatch", func() { sinkMapSS = rx.AllNamedGroups(bnANGDistinctRe, bnANGNoMatch) })
 	benchCase(b, "manyDuplicates", func() { sinkMapSS = rx.AllNamedGroups(bnANGManyDupRe, bnANGManyDupIn) }) // 20 appends + regrowth under one key
+}
+
+// ── NamedGroupsPerMatch ───────────────────────────────────────────────────────
+//
+// Cost model: like NamedGroups but over every match — FindAllStringSubmatchIndex
+// scans the whole target and allocates the index matrix, then one map is built
+// per match (map alloc + per-group insertion). The Seq form skips the outer
+// []map[string]string allocation but builds the same per-match maps. Cost
+// dimensions: match count and groups-per-match.
+
+var (
+	bnNGPMRe        = regexp.MustCompile(`(?P<key>\w+)=(?P<value>\w+)`)
+	bnNGPMIn        = strings.TrimSpace(strings.Repeat("a=1 b=2 ", 50)) // 100 matches
+	bnNGPMSingleIn  = "a=1"
+	bnNGPMNoMatchIn = "no key value pairs here"
+)
+
+func BenchmarkNamedGroupsPerMatch(b *testing.B) {
+	benchCase(b, "matches100", func() { sinkSliceMap = rx.NamedGroupsPerMatch(bnNGPMRe, bnNGPMIn) })     // representative batch
+	benchCase(b, "single", func() { sinkSliceMap = rx.NamedGroupsPerMatch(bnNGPMRe, bnNGPMSingleIn) })   // one match
+	benchCase(b, "noMatch", func() { sinkSliceMap = rx.NamedGroupsPerMatch(bnNGPMRe, bnNGPMNoMatchIn) }) // empty non-nil slice, early return
+}
+
+func BenchmarkNamedGroupsPerMatchSeq(b *testing.B) {
+	// Drains the iterator into the same per-match map sink; isolates the
+	// slice-allocation saving versus the eager NamedGroupsPerMatch above.
+	benchCase(b, "matches100", func() {
+		for m := range rx.NamedGroupsPerMatchSeq(bnNGPMRe, bnNGPMIn) {
+			sinkMap = m
+		}
+	})
 }
 
 // ── Replace ───────────────────────────────────────────────────────────────────

--- a/regextra_test.go
+++ b/regextra_test.go
@@ -290,6 +290,150 @@ func ExampleAllNamedGroups() {
 	// Output: word: [one two three]
 }
 
+func TestNamedGroupsPerMatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		target  string
+		want    []map[string]string
+	}{
+		{
+			name:    "multiple matches, one map per match",
+			pattern: `(?P<key>\w+)=(?P<value>\w+)`,
+			target:  "a=1 b=2 c=3",
+			want: []map[string]string{
+				{"key": "a", "value": "1"},
+				{"key": "b", "value": "2"},
+				{"key": "c", "value": "3"},
+			},
+		},
+		{
+			name:    "single match",
+			pattern: `(?P<name>\w+) (?P<age>\d+)`,
+			target:  "Alice 30",
+			want: []map[string]string{
+				{"name": "Alice", "age": "30"},
+			},
+		},
+		{
+			name:    "no match returns empty non-nil slice",
+			pattern: `(?P<word>[A-Z]+)`,
+			target:  "all lowercase",
+			want:    []map[string]string{},
+		},
+		{
+			// Duplicate name in one match: last participating occurrence wins,
+			// mirroring NamedGroups per-match semantics.
+			name:    "duplicate group name, last participating wins per match",
+			pattern: `(?P<word>\w+) (?P<word>\w+)`,
+			target:  "hello world foo bar",
+			want: []map[string]string{
+				{"word": "world"},
+				{"word": "bar"},
+			},
+		},
+		{
+			// Optional group that does not participate in a given match is still
+			// present, mapped to "" (includeNonParticipating=true).
+			name:    "non-participating optional group present as empty string",
+			pattern: `(?P<a>\w+)(?P<b>!)?`,
+			target:  "x! y",
+			want: []map[string]string{
+				{"a": "x", "b": "!"},
+				{"a": "y", "b": ""},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			re := regexp.MustCompile(tt.pattern)
+			got := rx.NamedGroupsPerMatch(re, tt.target)
+			if got == nil {
+				t.Fatalf("NamedGroupsPerMatch() = nil, want non-nil")
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NamedGroupsPerMatch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNamedGroupsPerMatchSeq(t *testing.T) {
+	t.Run("yields one map per match in order", func(t *testing.T) {
+		re := regexp.MustCompile(`(?P<key>\w+)=(?P<value>\w+)`)
+		want := []map[string]string{
+			{"key": "a", "value": "1"},
+			{"key": "b", "value": "2"},
+		}
+		var got []map[string]string
+		for m := range rx.NamedGroupsPerMatchSeq(re, "a=1 b=2") {
+			got = append(got, m)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("NamedGroupsPerMatchSeq() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("no match yields zero times", func(t *testing.T) {
+		re := regexp.MustCompile(`(?P<word>[A-Z]+)`)
+		count := 0
+		for range rx.NamedGroupsPerMatchSeq(re, "all lowercase") {
+			count++
+		}
+		if count != 0 {
+			t.Errorf("iterations = %d, want 0", count)
+		}
+	})
+
+	t.Run("break stops iteration early", func(t *testing.T) {
+		re := regexp.MustCompile(`(?P<word>\w+)`)
+		var got []string
+		for m := range rx.NamedGroupsPerMatchSeq(re, "alpha beta gamma") {
+			got = append(got, m["word"])
+			if len(got) == 2 {
+				break
+			}
+		}
+		want := []string{"alpha", "beta"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("after break, got = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("matches slice form", func(t *testing.T) {
+		re := regexp.MustCompile(`(?P<a>\w+)(?P<b>!)?`)
+		target := "x! y z!"
+		var seq []map[string]string
+		for m := range rx.NamedGroupsPerMatchSeq(re, target) {
+			seq = append(seq, m)
+		}
+		if !reflect.DeepEqual(seq, rx.NamedGroupsPerMatch(re, target)) {
+			t.Errorf("Seq form = %v, want parity with slice form %v", seq, rx.NamedGroupsPerMatch(re, target))
+		}
+	})
+}
+
+func ExampleNamedGroupsPerMatch() {
+	re := regexp.MustCompile(`(?P<key>\w+)=(?P<value>\w+)`)
+	all := rx.NamedGroupsPerMatch(re, "a=1 b=2")
+	for _, m := range all {
+		fmt.Printf("%s=%s\n", m["key"], m["value"])
+	}
+	// Output:
+	// a=1
+	// b=2
+}
+
+func ExampleNamedGroupsPerMatchSeq() {
+	re := regexp.MustCompile(`(?P<key>\w+)=(?P<value>\w+)`)
+	for m := range rx.NamedGroupsPerMatchSeq(re, "a=1 b=2") {
+		fmt.Printf("%s=%s\n", m["key"], m["value"])
+	}
+	// Output:
+	// a=1
+	// b=2
+}
+
 func TestReplace(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary
- Add `NamedGroupsPerMatch(re, target) []map[string]string` — one named-group map per match, the every-match counterpart to `NamedGroups`.
- Add `NamedGroupsPerMatchSeq(re, target) iter.Seq[map[string]string]` — the lazy range-over-func form that skips the slice allocation.
- Each per-match map mirrors `NamedGroups` semantics exactly (reuses `fillNamedGroupValues` + `FindAllStringSubmatchIndex`): every declared group present, non-participating groups mapped to `""`, reused names resolved to the last participating occurrence.
- Names deliberately avoid the overloaded "All" token (per the issue's mandate); also fixes the stale `AllNamedGroups` godoc/README note that disclaimed "no current function that returns every named group across every match".
- Docs: package "API at a glance" + "No-match behavior" table, README reference entries with runnable examples, CHANGELOG Unreleased entry.
- Tests: table tests (multi-match, single, no-match non-nil slice, duplicate names, non-participating optional group), Seq tests (order, zero-iteration no-match, early `break`, parity with slice form), runnable `Example` funcs, and benchmarks. New funcs at 100% coverage; package total 97% (above the 92% gate).

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `go vet ./...`, `gofmt -s -l .` (clean), `golangci-lint run` (0 issues)
- [x] Coverage: `NamedGroupsPerMatch`/`NamedGroupsPerMatchSeq` at 100%, total 97%

Fixes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)