### PR TITLE
chore: gitignore AGENTS.md and CLAUDE.md as personal workflow files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ Thumbs.db
 # Temporary files
 tmp/
 temp/
+
+# Personal agent/assistant workflow files (CONTRIBUTING.md is the source of truth)
+AGENTS.md
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,5 @@ tmp/
 temp/
 
 # Personal agent/assistant workflow files
-# (CONTRIBUTING.md is the source of truth for submitting code changes)
 AGENTS.md
 CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Thumbs.db
 tmp/
 temp/
 
-# Personal agent/assistant workflow files (CONTRIBUTING.md is the source of truth)
+# Personal agent/assistant workflow files
+# (CONTRIBUTING.md is the source of truth for submitting code changes)
 AGENTS.md
 CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,0 @@
-# Agent guide
-
-This file is the entry point for AI agents working in this repository.
-
-**Read [CONTRIBUTING.md](CONTRIBUTING.md) before making changes.** It is the
-authoritative contributor guide and applies equally to human and agent
-contributors. This file is only a pointer and intentionally holds no conventions
-of its own — everything you need is in CONTRIBUTING.md.

--- a/AGENTS.md.example
+++ b/AGENTS.md.example
@@ -1,5 +1,3 @@
-# Agent guide
-
 This file is the entry point for AI agents working in this repository.
 
 **Read [CONTRIBUTING.md](CONTRIBUTING.md) before making changes.** It is the

--- a/AGENTS.md.example
+++ b/AGENTS.md.example
@@ -1,0 +1,11 @@
+# Agent guide
+
+This file is the entry point for AI agents working in this repository.
+
+**Read [CONTRIBUTING.md](CONTRIBUTING.md) before making changes.** It is the
+authoritative contributor guide and applies equally to human and agent
+contributors — the source of truth for submitting code changes. This file holds
+no conventions of its own; everything you need is in CONTRIBUTING.md.
+
+<!-- Personal, gitignored copy. Copy this file to AGENTS.md and add your own
+     workflow notes below — they stay local and are never committed. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,0 @@
-See [AGENTS.md](AGENTS.md) for agent guidance, which points to
-[CONTRIBUTING.md](CONTRIBUTING.md) as the authoritative contributor guide.

--- a/CLAUDE.md.example
+++ b/CLAUDE.md.example
@@ -1,4 +1,5 @@
-This file is the entry point for AI agents working in this repository using claude.
+This file is the entry point for AI agents working in this repository using
+claude code.
 
 **Read [CONTRIBUTING.md](CONTRIBUTING.md) before making changes.** It is the
 authoritative contributor guide and applies equally to human and agent

--- a/CLAUDE.md.example
+++ b/CLAUDE.md.example
@@ -1,5 +1,4 @@
-See [AGENTS.md](AGENTS.md) for agent guidance, which points to
-[CONTRIBUTING.md](CONTRIBUTING.md) as the authoritative contributor guide and
+See [CONTRIBUTING.md](CONTRIBUTING.md) as the authoritative contributor guide and
 the source of truth for submitting code changes.
 
 <!-- Personal, gitignored copy. Copy this file to CLAUDE.md and add your own

--- a/CLAUDE.md.example
+++ b/CLAUDE.md.example
@@ -1,6 +1,9 @@
-See [CONTRIBUTING.md](CONTRIBUTING.md) as the authoritative contributor guide and
-the source of truth for submitting code changes.
+This file is the entry point for AI agents working in this repository using claude.
+
+**Read [CONTRIBUTING.md](CONTRIBUTING.md) before making changes.** It is the
+authoritative contributor guide and applies equally to human and agent
+contributors — the source of truth for submitting code changes. This file holds
+no conventions of its own; everything you need is in CONTRIBUTING.md.
 
 <!-- Personal, gitignored copy. Copy this file to CLAUDE.md and add your own
-     workflow notes below — e.g. a preferred VCS like jj. They stay local and
-     are never committed. -->
+     workflow notes below — they stay local and are never committed. -->

--- a/CLAUDE.md.example
+++ b/CLAUDE.md.example
@@ -1,0 +1,7 @@
+See [AGENTS.md](AGENTS.md) for agent guidance, which points to
+[CONTRIBUTING.md](CONTRIBUTING.md) as the authoritative contributor guide and
+the source of truth for submitting code changes.
+
+<!-- Personal, gitignored copy. Copy this file to CLAUDE.md and add your own
+     workflow notes below — e.g. a preferred VCS like jj. They stay local and
+     are never committed. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,16 +47,17 @@ gofmt -s -l .
 #### Optional: personal agent/assistant files
 
 `AGENTS.md` and `CLAUDE.md` are gitignored so you can keep personal
-agent/assistant workflow notes (e.g. a preferred VCS like `jj`) without
-committing them. To start from the tracked templates:
+agent/assistant workflow notes without committing them. They should defer
+to CONTRIBUTING.md for repo code changes/expectations. To start from the
+tracked templates depending on your agent/harness:
 
-```bash
+```sh
 cp AGENTS.md.example AGENTS.md
+```
+or
+```sh
 cp CLAUDE.md.example CLAUDE.md
 ```
-
-These copies stay local; CONTRIBUTING.md remains the source of truth for
-submitting code changes.
 
 ## Code Standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,20 @@ go vet ./...
 gofmt -s -l .
 ```
 
+#### Optional: personal agent/assistant files
+
+`AGENTS.md` and `CLAUDE.md` are gitignored so you can keep personal
+agent/assistant workflow notes (e.g. a preferred VCS like `jj`) without
+committing them. To start from the tracked templates:
+
+```bash
+cp AGENTS.md.example AGENTS.md
+cp CLAUDE.md.example CLAUDE.md
+```
+
+These copies stay local; CONTRIBUTING.md remains the source of truth for
+submitting code changes.
+
 ## Code Standards
 
 ### Testing
@@ -142,6 +156,8 @@ regextra/
 ├── bench_internal_test.go # package-internal benchmark (touches unexported code)
 ├── bench_sanity_test.go   # asserts the shared benchmark fixtures stay representative
 ├── README.md              # Public API documentation
+├── AGENTS.md.example      # Template for a personal (gitignored) agent guide
+├── CLAUDE.md.example      # Template for a personal (gitignored) Claude Code guide
 ├── CONTRIBUTING.md         # This file
 ├── CHANGELOG.md           # Version history
 ├── go.mod                 # Module definition

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,8 +142,6 @@ regextra/
 ├── bench_internal_test.go # package-internal benchmark (touches unexported code)
 ├── bench_sanity_test.go   # asserts the shared benchmark fixtures stay representative
 ├── README.md              # Public API documentation
-├── AGENTS.md              # AI-agent entry point (pointer to this guide)
-├── CLAUDE.md              # Claude Code entry point (points to AGENTS.md/this guide)
 ├── CONTRIBUTING.md         # This file
 ├── CHANGELOG.md           # Version history
 ├── go.mod                 # Module definition


### PR DESCRIPTION
## Summary
- Untrack `AGENTS.md` and `CLAUDE.md` (`git rm --cached`) and add them to `.gitignore` so contributors can keep personal agent/assistant workflow notes — e.g. a `jj` preference — without committing them.
- `CONTRIBUTING.md` remains the single source of truth; removed the two now-untracked files from its project-structure tree.
- Local copies stay on disk; only tracking changes.

## Test plan
- [x] `git check-ignore AGENTS.md CLAUDE.md` confirms both are now ignored.
- [x] Both files remain on disk after `git rm --cached` (not deleted from the working tree).
- [x] No Go code changed — build/tests unaffected.

Fixes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)