### PR TITLE
test: cover Replace's documented non-participating and unnamed-group behaviors

### DIFF
--- a/regextra_test.go
+++ b/regextra_test.go
@@ -517,6 +517,25 @@ func TestReplace(t *testing.T) {
 			repl:    map[string]string{"inner": "X"},
 			want:    "X@example.com",
 		},
+		{
+			// A named group that does not participate in the match (the
+			// optional group is absent) is silently skipped; the rest of the
+			// match still substitutes.
+			name:    "non-participating optional group is skipped",
+			pattern: `(?P<num>\d+)(?P<sign>%)?`,
+			target:  "value 50 end",
+			repl:    map[string]string{"num": "N", "sign": "S"},
+			want:    "value N end",
+		},
+		{
+			// Unnamed groups mixed with named groups: only the named group is
+			// substituted; the unnamed group's text passes through untouched.
+			name:    "unnamed group mixed with named is left untouched",
+			pattern: `(\w+)=(?P<val>\d+)`,
+			target:  "a=1 b=2",
+			repl:    map[string]string{"val": "?"},
+			want:    "a=? b=?",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add a `TestReplace` case for a **non-participating optional named group** (`(?P<sign>%)?` absent from the match) — asserts the absent group is silently skipped while the rest of the match still substitutes (`replaceNamed` `s < 0 || e < 0` branch).
- Add a `TestReplace` case for an **unnamed group mixed with named groups** (`(\w+)=(?P<val>\d+)`) — asserts the unnamed group passes through untouched and only the named group is replaced (`replaceNamed` `name == ""` branch).
- The third documented behavior in the issue — nested "outermost wins" — was already covered by the two cases added in #107, so no new case is needed there. (The issue's "90.6% / zero coverage" framing predates #107.)

These are data-only additions to the existing `TestReplace` table; no production code changes.

## Test plan
- [x] `go test -race ./...` passes
- [x] `go test -run TestReplace -coverprofile` shows `replaceNamed` at 100%, with the `name == ""` and `s < 0` skip branches now attributable to `TestReplace` specifically
- [x] `gofmt -s -l .` clean, `go vet ./...` clean

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)