### PR TITLE
docs(contributing): document commit signing and issue-closing keywords

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,9 +204,23 @@ go test -bench=. -benchmem
 ### PR Guidelines
 - **One feature per PR**: Keep changes focused
 - **Write clear descriptions**: Explain what and why
-- **Reference issues**: Link related issues or discussions
+- **Reference issues**: Link related issues or discussions. If the PR resolves
+  an issue, use a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
+  (`Closes #NN` / `Fixes #NN`) in the description so it auto-closes on merge
 - **Update tests**: Include test coverage for changes
 - **Breaking changes**: Clearly document in PR
+
+### Commit Signing
+
+**Every commit in a PR must be verified (cryptographically signed).** GitHub
+must show each commit as **Verified**; a PR with any unsigned/unverified commit
+will not be merged. Configure signing once (SSH or GPG) and it applies to all
+your commits:
+
+- See [GitHub's guide on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+- Add your signing key to your GitHub account so the signature verifies.
+- If a commit landed unsigned, re-sign it (amend/rebase with your signing key,
+  or your VCS's equivalent) and force-push the branch before requesting merge.
 
 ### Commit Message Format
 


### PR DESCRIPTION
## What

Expands `CONTRIBUTING.md`'s Pull Request Process with two tracked-policy notes:

- **Commit Signing** — every commit in a PR must be verified (signed); GitHub must show each commit as **Verified**, and a PR with any unverified commit will not be merged. Includes a pointer to GitHub's signing guide and the re-sign/force-push remedy.
- **Issue-closing keywords** — when a PR resolves an issue, use a closing keyword (`Closes #NN` / `Fixes #NN`) in the description so the issue auto-closes on merge.

## Why

The signing requirement previously lived only in a personal, gitignored `CLAUDE.md`, so it wasn't discoverable or a tracked source of truth. Moving it into `CONTRIBUTING.md` makes it the authoritative, repo-visible policy. Surfaced while addressing review feedback on #157, whose blocking finding cited this rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)