### PR TITLE
perf: trim off-hot-path allocations in AllNamedGroups

### DIFF
--- a/regextra.go
+++ b/regextra.go
@@ -437,8 +437,8 @@ func fillNamedGroupValues(dst map[string]string, names []string, target string, 
 // Groups that appear once still get a one-element slice.
 //
 // The leading "All" refers to all named groups in one match — not to all
-// matches across the target. Internally the function calls FindStringSubmatch,
-// so only the first match contributes values. To collect every value of a
+// matches across the target. Internally the function inspects only the first
+// match, so only the first match contributes values. To collect every value of a
 // single named group across every match in the target, use [FindAllNamed]. To
 // collect every named group across every match as one map per match, use
 // [NamedGroupsPerMatch] (or [NamedGroupsPerMatchSeq] for the lazy form); the
@@ -460,17 +460,30 @@ func fillNamedGroupValues(dst map[string]string, names []string, target string, 
 //	allGroups := regextra.AllNamedGroups(re, "Alice 30")
 //	// allGroups = map[string][]string{"name": []string{"Alice"}, "age": []string{"30"}}
 func AllNamedGroups(re *regexp.Regexp, target string) map[string][]string {
+	names := re.SubexpNames()
+	// No map size hint: len(names) counts slots, not distinct names, so it
+	// over-allocates when a pattern reuses one name across many occurrences.
 	result := make(map[string][]string)
 
-	matches := re.FindStringSubmatch(target)
-	if matches == nil {
+	// Index form returns only the match offsets ([]int); we slice each
+	// participating group out of target directly. FindStringSubmatch would
+	// additionally allocate a []string of every group just to read it once.
+	loc := re.FindStringSubmatchIndex(target)
+	if loc == nil {
 		return result
 	}
 
-	for i, name := range re.SubexpNames() {
-		if i != 0 && name != "" {
-			result[name] = append(result[name], matches[i])
+	for i, name := range names {
+		if i == 0 || name == "" {
+			continue
 		}
+		// A non-participating group has start < 0; preserve
+		// FindStringSubmatch's behavior of contributing "" for it.
+		value := ""
+		if start := loc[2*i]; start >= 0 {
+			value = target[start:loc[2*i+1]]
+		}
+		result[name] = append(result[name], value)
 	}
 
 	return result
@@ -626,8 +639,9 @@ func replaceNamed(re *regexp.Regexp, target string, replFor func(name, matched s
 //	    // err: regextra.Validate: missing named groups: missing
 //	}
 func Validate(re *regexp.Regexp, required ...string) error {
-	declared := make(map[string]struct{}, len(re.SubexpNames()))
-	for _, n := range re.SubexpNames() {
+	names := re.SubexpNames()
+	declared := make(map[string]struct{}, len(names))
+	for _, n := range names {
 		if n != "" {
 			declared[n] = struct{}{}
 		}


### PR DESCRIPTION
## Summary
- Switch `AllNamedGroups` from `FindStringSubmatch` to `FindStringSubmatchIndex`, slicing each participating group out of `target` directly — the same index-form pattern its `FindNamed`/`FindAllNamed` siblings already use. This drops the full-submatch `[]string` allocated per call. Behavior is preserved, including contributing `""` for declared-but-non-participating groups.
- Drop the map size hint idea from the plan: `len(names)` counts name *slots*, not distinct keys, so presizing over-allocated the map when a pattern reuses one name (it regressed `manyDuplicates`). Removed to keep every case neutral-or-better.
- Tidy: hoist the double `re.SubexpNames()` call in `Validate` into one local (no alloc change).
- `decoder.go`/`subexpIndexes` fast path from the plan was left out — it was gated on "only if a bench shows it matters", and no benched win materialized, so no churn.

## Benchmarks
`go test -run=^$ -bench='BenchmarkAllNamedGroups|BenchmarkValidate' -benchmem -benchtime=100ms -count=6` (Apple Silicon, arm64). Per CONTRIBUTING benchmark validation:

| case | before | after |
|---|---|---|
| AllNamedGroups/distinctGroups | 548 B/op, 6 allocs/op | 482 B/op, 5 allocs/op |
| AllNamedGroups/duplicateGroupName | 644 B/op, 7 allocs/op | 579 B/op, 6 allocs/op |
| AllNamedGroups/manyDuplicates | 2128 B/op, 10 allocs/op | 1772 B/op, 9 allocs/op |
| AllNamedGroups/noMatch | 48 B/op, 1 allocs/op | 48 B/op, 1 allocs/op (neutral) |
| Validate/* | unchanged | unchanged |

Each contributing case drops one alloc and B/op; no regressions.

## Test plan
- [x] `go test -race ./...` green
- [x] `go vet ./...` clean, `gofmt -l` clean
- [x] `go test -cover .` = 98.1% (>92% floor); existing `AllNamedGroups` cases (distinct, duplicate, no-match) cover behavior preservation
- [x] Before/after benchmarks recorded above

Fixes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved named-group extraction so empty but present groups are now preserved correctly in results.
  * Ensured only the first match is used consistently when collecting group values.

* **Refactor**
  * Streamlined validation logic for better internal efficiency without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->