### PR TITLE
feat: add Decoder.Regexp() accessor for the compiled pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,18 @@ for v, err := range personDecoder.Iter(input) {
 
 `Iter` returns an `iter.Seq2[T, error]` (Go 1.23+ range-over-func). Use it for streaming-style consumption (log parsers, scrapers) where you don't want to allocate the full slice up-front. **~37% faster and ~50% fewer allocations** than `UnmarshalAll` on a 100-line corpus, since Iter skips the slice allocation entirely. Match-finding still happens in one regex call (Go's stdlib doesn't expose a streaming-find API), but the per-match decode work IS lazy — `break` in the range body avoids decoding the remaining matches.
 
+**Accessors.** A `Decoder` exposes the pattern it was compiled from, so you don't have to keep a copy alongside it:
+
+- `Pattern() string` returns the regex source string — handy for logging and debugging.
+- `Regexp() *regexp.Regexp` returns the underlying compiled `*regexp.Regexp`, so you can reuse it for your own match-finding (e.g. `FindAllIndex`, custom iteration) without recompiling. The returned pointer is shared with the `Decoder`: its exported methods are read-only and safe for concurrent use, but do not mutate shared matcher state on it — in particular don't call `Longest()`, which changes matching semantics for the `Decoder` too.
+
+```go
+dec := regextra.MustCompile[Person](`(?P<name>\w+) is (?P<age>\d+)`)
+dec.Pattern()          // "(?P<name>\\w+) is (?P<age>\\d+)"
+dec.Regexp().FindAllString("Alice is 30 and Bob is 25", -1)
+// []string{"Alice is 30", "Bob is 25"}
+```
+
 `Decoder` instances are safe for concurrent use.
 
 ## Why regextra?

--- a/decoder.go
+++ b/decoder.go
@@ -339,6 +339,18 @@ func (d *Decoder[T]) Pattern() string {
 	return d.pattern
 }
 
+// Regexp returns the compiled [*regexp.Regexp] this Decoder built from its
+// pattern, so callers can reuse it for their own match-finding (for example
+// [regexp.Regexp.FindAllIndex] or custom iteration) without recompiling.
+//
+// The returned pointer is shared with the Decoder. Its exported methods are
+// read-only and safe for concurrent use, but callers must not mutate shared
+// state on it — in particular do not call [regexp.Regexp.Longest], which
+// changes the receiver's matching semantics and would affect the Decoder too.
+func (d *Decoder[T]) Regexp() *regexp.Regexp {
+	return d.re
+}
+
 // decode walks the precomputed field plan against a single match and writes the
 // values into rv (the addressable reflect.Value of a T). It is a thin wrapper
 // over the shared runDecodePlan core, which the [Unmarshal] / [UnmarshalAll]

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -434,6 +434,33 @@ func ExampleDecoder_Iter() {
 	// Bob/25
 }
 
+func ExampleDecoder_Pattern() {
+	type Entry struct {
+		Name string `regex:"name"`
+		Age  int    `regex:"age"`
+	}
+	dec := rx.MustCompile[Entry](`(?P<name>\w+) is (?P<age>\d+)`)
+	// Pattern returns the regex source the Decoder was compiled from.
+	fmt.Println(dec.Pattern())
+	// Output: (?P<name>\w+) is (?P<age>\d+)
+}
+
+func ExampleDecoder_Regexp() {
+	type Entry struct {
+		Name string `regex:"name"`
+		Age  int    `regex:"age"`
+	}
+	dec := rx.MustCompile[Entry](`(?P<name>\w+) is (?P<age>\d+)`)
+	// Regexp exposes the compiled *regexp.Regexp for your own match-finding,
+	// without recompiling the pattern. Treat it as read-only.
+	for _, m := range dec.Regexp().FindAllString("Alice is 30 and Bob is 25", -1) {
+		fmt.Println(m)
+	}
+	// Output:
+	// Alice is 30
+	// Bob is 25
+}
+
 // ── Iter ──────────────────────────────────────────────────────────────────────
 
 func TestDecoder_Iter_yieldsEveryMatch(t *testing.T) {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -29,6 +29,30 @@ func TestCompile_simpleStruct(t *testing.T) {
 	}
 }
 
+func TestDecoder_Regexp(t *testing.T) {
+	type P struct {
+		Name string `regex:"name"`
+		Age  int    `regex:"age"`
+	}
+	d, err := rx.Compile[P](`(?P<name>\w+) is (?P<age>\d+)`)
+	if err != nil {
+		t.Fatalf("Compile returned %v", err)
+	}
+	re := d.Regexp()
+	if re == nil {
+		t.Fatal("Regexp() = nil, want the compiled pattern")
+	}
+	if re.String() != d.Pattern() {
+		t.Errorf("Regexp().String() = %q, want Pattern() %q", re.String(), d.Pattern())
+	}
+	// The returned pattern is usable for the caller's own match-finding.
+	got := re.FindAllString("bob is 30 alice is 25", -1)
+	want := []string{"bob is 30", "alice is 25"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FindAllString via Regexp() = %v, want %v", got, want)
+	}
+}
+
 func TestCompile_fieldNameFallback(t *testing.T) {
 	type P struct {
 		Name string // no tag — should match group "name" via case-insensitive fallback


### PR DESCRIPTION
## Summary
- Add `func (d *Decoder[T]) Regexp() *regexp.Regexp` to expose the compiled pattern the `Decoder[T]` already holds, so callers can reuse it for their own match-finding (`FindAllIndex`, custom iteration) without recompiling.
- Placed beside the existing `Pattern()` accessor; no new state or compilation.
- Doc comment warns callers not to mutate shared state on the returned value, calling out `(*regexp.Regexp).Longest()` specifically. Additive, non-breaking.

## Test plan
- [x] `go test ./...` passes with new `TestDecoder_Regexp` (non-nil, `Regexp().String() == Pattern()`, drives `FindAllString`).
- [x] `go vet ./...` clean; new exported method has a godoc doc comment.

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public accessors to retrieve the decoder’s compiled regular expression for read-only reuse.
  * The shared matcher is safe for concurrent read operations, with guidance not to mutate shared matcher state.
* **Documentation**
  * Updated the README with the new accessors and a Go example showing how to reuse the compiled matcher.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->