### PR TITLE
chore: public-contract accuracy & consistency audit before v2 (docs + error-type fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ For a single match, prefer `FindNamed`. To pull every named group from one match
 
 ### `NamedGroups(re *regexp.Regexp, target string) map[string]string`
 
-Extract all named capture groups as a map. If a group name appears multiple times, only the last match is returned.
+Extract all named capture groups as a map. If a group name appears multiple times (e.g. across alternation branches), the value of the last occurrence that participated in the match wins; a non-participating occurrence never overwrites a participating one.
 
 Returns an empty map if no match is found.
 
@@ -227,12 +227,12 @@ if errors.As(err, &ve) {
 
 Unmarshal regex matches into a struct with automatic type conversion. Similar to `json.Unmarshal`, but for regex patterns.
 
-**Supported field types:** `string`, `int`, `int8`, `int16`, `int32`, `int64`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `float32`, `float64`, `bool`, `time.Time`, `time.Duration`. Pointer-to-any-of-the-above is also supported — nil pointers are allocated, non-nil pointers are reused (pointee overwritten). For `time.Time`, several common layouts are tried (RFC3339, RFC3339Nano, `2006-01-02 15:04:05`, `2006-01-02`, `15:04:05`); `time.Duration` is parsed via `time.ParseDuration`. Any field whose type (or pointer-to-type) implements [`encoding.TextUnmarshaler`](https://pkg.go.dev/encoding#TextUnmarshaler) is also supported out of the box — e.g. `netip.Addr`, `math/big.Int`, `log/slog.Level`, `github.com/google/uuid.UUID` — by calling its `UnmarshalText` with the matched value. For caller-defined types, implement [`RegexUnmarshaler`](#regexunmarshaler-interface).
+**Supported field types:** `string`, `int`, `int8`, `int16`, `int32`, `int64`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `float32`, `float64`, `bool`, `time.Time`, `time.Duration`. Pointer-to-any-of-the-above is also supported — nil pointers are allocated, non-nil pointers are reused (pointee overwritten). For `time.Time`, several common layouts are tried in order (RFC3339Nano, RFC3339, `2006-01-02 15:04:05`, `2006-01-02`, `15:04:05`); `time.Duration` is parsed via `time.ParseDuration`. Any field whose type (or pointer-to-type) implements [`encoding.TextUnmarshaler`](https://pkg.go.dev/encoding#TextUnmarshaler) is also supported out of the box — e.g. `netip.Addr`, `math/big.Int`, `log/slog.Level`, `github.com/google/uuid.UUID` — by calling its `UnmarshalText` with the matched value. For caller-defined types, implement [`RegexUnmarshaler`](#regexunmarshaler-interface).
 
 **Field mapping priority:**
 1. Struct tag `regex:"groupname"` if provided (highest priority)
 2. Exact field name match with capture group name
-3. Case-insensitive field name match
+3. Case-insensitive field name match (Unicode simple case folding)
 - Unexported fields are ignored
 
 Returns an error if the target is not a pointer to a struct, or if type conversion fails.
@@ -379,7 +379,7 @@ people, _ := personDecoder.All("Alice is 30 and Bob is 25")
 // people = []Person{{"Alice", 30}, {"Bob", 25}}
 ```
 
-**vs `Unmarshal`:** the same simple-struct shape benchmarks at **~270 ns/op (3 allocs)** via `Decoder` versus **~500 ns/op (6 allocs)** via `Unmarshal` on Apple M4 — roughly half the time and half the allocations. Use `Decoder` when you'll decode the same shape many times (log parsers, config readers, request handlers); use `Unmarshal` for one-shot extraction.
+**vs `Unmarshal`:** the same simple-struct shape benchmarks at **~255 ns/op (2 allocs)** via `Decoder` versus **~540 ns/op (11 allocs)** via `Unmarshal` on Apple M4 — roughly half the time and far fewer allocations (measurements are hardware-dependent, not a guarantee). Use `Decoder` when you'll decode the same shape many times (log parsers, config readers, request handlers); use `Unmarshal` for one-shot extraction.
 
 **Compile-time validation is strict.** `Compile` returns an error (or `MustCompile` panics) if:
 - The pattern is not a valid regex
@@ -423,7 +423,7 @@ if errors.As(err, &rge) {
 }
 ```
 
-Constructed errors are prefixed with the entrypoint that produced them (`regextra.Unmarshal:`, `regextra.Decoder.One:`, …); the bare `regextra:` prefix is reserved for package-level sentinels like `ErrNoMatch`, `ErrInvalidPattern`, and `ErrInvalidStruct`. Treat these prefixes as informational — compare against the sentinel or the `*DecodeError` type, not the string.
+Constructed errors are prefixed with the entrypoint that produced them (`regextra.Unmarshal:`, `regextra.Decoder.One:`, …); the bare `regextra:` prefix is reserved for package-level sentinels like `ErrNoMatch`, `ErrInvalidPattern`, and `ErrInvalidStruct`. One intended exception: the construction-time errors from `Compile` / `MustCompile` and `Decoder.Encoder()` carry the bare `regextra:` prefix rather than a `regextra.Compile:` / `regextra.Decoder.Encoder:` entrypoint prefix, because they wrap the `ErrInvalidPattern` / `ErrInvalidStruct` / `ErrNotInvertible` sentinels directly — so a `regextra:`-prefixed message there is by design, not a missing prefix. Treat these prefixes as informational — compare against the sentinel or the `*DecodeError` type, not the string.
 
 **Streaming with `Decoder.Iter`:**
 
@@ -439,7 +439,7 @@ for v, err := range personDecoder.Iter(input) {
 }
 ```
 
-`Iter` returns an `iter.Seq2[T, error]` (Go 1.23+ range-over-func). Use it for streaming-style consumption (log parsers, scrapers) where you don't want to allocate the full slice up-front. **~37% faster and ~50% fewer allocations** than `UnmarshalAll` on a 100-line corpus, since Iter skips the slice allocation entirely. Match-finding still happens in one regex call (Go's stdlib doesn't expose a streaming-find API), but the per-match decode work IS lazy — `break` in the range body avoids decoding the remaining matches.
+`Iter` returns an `iter.Seq2[T, error]` (Go 1.23+ range-over-func). Use it for streaming-style consumption (log parsers, scrapers) where you don't want to materialize the full result slice up-front. On a full 100-line corpus its throughput is roughly comparable to `UnmarshalAll` (≈28 µs/op, ~205 allocs/op vs ≈26 µs/op, ~114 allocs/op on Apple M4 — hardware-dependent, not a guarantee); `Iter`'s win is streaming, not raw speed. It skips allocating the full result slice (lower peak memory on large inputs) and decodes lazily. Match-finding still happens in one regex call (Go's stdlib doesn't expose a streaming-find API), but the per-match decode work IS lazy — `break` in the range body avoids decoding the remaining matches.
 
 **Accessors.** A `Decoder` exposes the pattern it was compiled from, so you don't have to keep a copy alongside it:
 

--- a/decoder.go
+++ b/decoder.go
@@ -84,7 +84,9 @@ type fieldDecoder struct {
 // Returns an error if:
 //   - pattern is not a valid regular expression
 //   - T is not a struct type
-//   - A field's `regex:"name"` tag references a group not declared on pattern
+//   - A field's `regex:"name"` tag references a group not declared on pattern,
+//     and the field has no `default=` (a `default=` makes a missing group
+//     intentional, so the field compiles and the default always fires)
 //   - A field's `regex:",default=<value>"` cannot be converted to the field's type
 //   - A field uses `regex:",layout=..."` on a non-time.Time field
 //
@@ -282,9 +284,10 @@ func resolveGroupName(re *regexp.Regexp, sf reflect.StructField, groupIndexes []
 }
 
 // One returns the result of decoding the first match of d's pattern in target.
-// Returns [ErrNoMatch] if there's no match. Other errors indicate a per-field
-// conversion failure (a [DecodeError]); in that case the returned T contains
-// whatever fields were successfully decoded before the failure. A matched field
+// Returns [ErrNoMatch] if there's no match. Other errors indicate either a
+// per-field conversion failure (a [DecodeError]) or a `required` group that
+// produced no value (a [RequiredGroupError]); in that case the returned T
+// contains whatever fields were successfully decoded before the failure. A matched field
 // whose type is a nested struct, slice, or map is one such failure: these are
 // not flattened, so binding a group to one yields an "unsupported field type"
 // error (unless the type implements [RegexUnmarshaler] or
@@ -310,8 +313,9 @@ func (d *Decoder[T]) One(target string) (T, error) {
 
 // All returns every match of d's pattern in target decoded into a slice.
 // Returns an empty slice and nil error when there are no matches. A non-nil
-// error indicates a per-field conversion failure on one of the matches; the
-// slice up to that point may contain partially-decoded entries.
+// error indicates a per-field conversion failure (a [DecodeError]) or a
+// `required` group that produced no value (a [RequiredGroupError]) on one of the
+// matches; the slice up to that point may contain partially-decoded entries.
 func (d *Decoder[T]) All(target string) ([]T, error) {
 	allMatches := d.re.FindAllStringSubmatchIndex(target, -1)
 	if len(allMatches) == 0 {
@@ -329,8 +333,9 @@ func (d *Decoder[T]) All(target string) ([]T, error) {
 
 // Iter returns a range-over-func iterator that decodes each match of d's
 // pattern in target into a T, yielded with the per-match decode error.
-// nil error means decoded successfully; non-nil means a per-field
-// conversion failed on that match. Iteration continues past errors so
+// nil error means decoded successfully; non-nil means a per-field conversion
+// failed (a [DecodeError]) or a `required` group produced no value (a
+// [RequiredGroupError]) on that match. Iteration continues past errors so
 // callers can collect or skip individual failures:
 //
 //	for v, err := range dec.Iter(input) {

--- a/decoder.go
+++ b/decoder.go
@@ -174,9 +174,9 @@ func buildDecodePlan(rt reflect.Type, re *regexp.Regexp, strict bool) ([]fieldDe
 		if groupName == "" {
 			// No explicit tag — fall back to matching the field name against a
 			// declared group: exact first, then case-insensitively via Unicode
-			// simple-fold (see matchGroupName). A field that matches no group
-			// and has no default is treated as a typo and, under strict, fails
-			// the build below.
+			// simple case folding (see matchGroupName). A field that matches
+			// no group and has no default is treated as a typo and, under
+			// strict, fails the build below.
 			groupName = matchGroupName(re, sf.Name)
 		}
 
@@ -249,8 +249,9 @@ func subexpIndexes(re *regexp.Regexp, name string) []int {
 }
 
 // matchGroupName returns the declared group name on re that matches fieldName
-// (case-insensitive), or "" if no group matches. Used as a fallback when a
-// field has no explicit `regex:"..."` tag.
+// (exactly, then case-insensitively via Unicode simple case folding), or ""
+// if no group matches. Used as a fallback when a field has no explicit
+// `regex:"..."` tag.
 func matchGroupName(re *regexp.Regexp, fieldName string) string {
 	if idx := re.SubexpIndex(fieldName); idx != -1 {
 		return fieldName

--- a/encoder.go
+++ b/encoder.go
@@ -59,6 +59,16 @@ var ErrNotInvertible = errors.New("regextra: pattern is not invertible")
 // to read fields, but does no per-call field-mapping reflection — the field↦group
 // resolution is cached in the plan at construction.
 //
+// # Supported field types
+//
+// A named group resolves to a field whose type Encode can render — the same set
+// [Unmarshal] accepts on the decode side: string, bool, all int/uint widths,
+// float32/float64, time.Time, time.Duration, a type implementing [RegexMarshaler]
+// or [encoding.TextMarshaler], and pointers (any depth) to any of these. A
+// mapped field of any other type makes [Decoder.Encoder] fail with
+// [ErrInvalidStruct]. A time.Time field honors a `layout=` tag option and
+// otherwise emits RFC3339Nano.
+//
 // # Round-trip contract
 //
 // Encode(v) re-decodes to v when each encoded value re-matches the sub-pattern of
@@ -140,8 +150,8 @@ var (
 //	}
 //
 // Err holds the underlying cause (e.g. an error from a custom [RegexMarshaler]
-// or [encoding.TextMarshaler], or a nil-pointer field) and is reachable via
-// [errors.Is]/[errors.As] through Unwrap.
+// or [encoding.TextMarshaler], or a nil-pointer or nil-interface field) and is
+// reachable via [errors.Is]/[errors.As] through Unwrap.
 type EncodeError struct {
 	// Field is the source struct field name.
 	Field string
@@ -185,7 +195,7 @@ func (e *EncodeError) Unwrap() error { return e.Err }
 // The latter two wrap [ErrInvalidStruct], mirroring [Compile]. Once Encoder
 // returns nil, the resulting Encoder is fully validated: the only errors
 // [Encoder.Encode] can then surface are runtime value failures (a custom
-// marshaler returning an error, or a nil pointer field).
+// marshaler returning an error, or a nil pointer or nil interface field).
 func (d *Decoder[T]) Encoder() (*Encoder[T], error) {
 	var zero T
 	rt := reflect.TypeOf(zero)
@@ -455,7 +465,8 @@ func encodableType(t reflect.Type) bool {
 //
 // Returns an [EncodeError] (wrapped with the entrypoint prefix) if a field
 // cannot be rendered at runtime — a custom [RegexMarshaler] / [encoding.TextMarshaler]
-// returning an error, or a nil pointer field, which has no string form.
+// returning an error, or a nil pointer or nil interface field, which has no
+// string form.
 //
 // The `default=` tag option does not affect encoding: it is a decode-side
 // substitution for an absent group, whereas Encode always emits the field's

--- a/encoder.go
+++ b/encoder.go
@@ -167,8 +167,15 @@ type EncodeError struct {
 }
 
 // Error implements the error interface. The calling entrypoint prepends its own
-// `regextra.<Entrypoint>:` prefix when wrapping.
+// `regextra.<Entrypoint>:` prefix when wrapping. When Err is nil (only reachable
+// by constructing the value directly — the encode path always sets an underlying
+// cause) it reports "no encode error" rather than a message with a dangling
+// "<nil>" cause, mirroring [DecodeError], [RequiredGroupError], and
+// [MissingNamedGroupsError].
 func (e *EncodeError) Error() string {
+	if e.Err == nil {
+		return "no encode error"
+	}
 	return fmt.Sprintf("field %s: %v", e.Field, e.Err)
 }
 

--- a/encoder.go
+++ b/encoder.go
@@ -42,7 +42,7 @@ var ErrNotInvertible = errors.New("regextra: pattern is not invertible")
 //   - A named capture group `(?P<name>…)` becomes a field substitution: name
 //     resolves to a struct field with the same rules [Decoder] uses — the field's
 //     `regex:"name"` tag matched exactly, otherwise the field's own name matched
-//     exactly then case-insensitively via Unicode simple-fold; a `regex:"-"` field
+//     exactly then case-insensitively via Unicode simple case folding; a `regex:"-"` field
 //     is excluded. The group's sub-pattern is discarded — the field's value fills
 //     the span.
 //   - Anchors and zero-width assertions (`^`, `$`, `\A`, `\z`, `\b`, …) match no
@@ -148,7 +148,7 @@ type EncodeError struct {
 	// Group is the capture-group name the field resolved from: the field's
 	// `regex:"..."` tag name when set, otherwise the declared group whose name
 	// matches the field name — which may differ from the field name in case when
-	// the two matched via Unicode simple-fold. Mirrors [DecodeError].Group.
+	// the two matched via Unicode simple case folding. Mirrors [DecodeError].Group.
 	Group string
 	// Type is the source field's type, rendered (e.g. "int", "time.Time").
 	Type string

--- a/encoder.go
+++ b/encoder.go
@@ -364,9 +364,9 @@ func notInvertibleError(construct string) error {
 // resolveEncodeField maps a capture-group name to an exported, non-excluded field
 // of rt, using the same field-mapping rules the decode side applies: a field's
 // `regex:"name"` tag matched exactly, otherwise the field's own name matched
-// exactly first and then case-insensitively via Unicode simple-fold (mirroring
-// matchGroupName). Returns the field index, its parsed tag options, and true on
-// a match; ("", nil, false) when no field resolves.
+// exactly first and then case-insensitively via Unicode simple case folding
+// (mirroring matchGroupName). Returns the field index, its parsed tag options,
+// and true on a match; ("", nil, false) when no field resolves.
 func resolveEncodeField(rt reflect.Type, name string) (int, map[string]string, bool) {
 	// Exact pass first so an exact name never loses to an earlier fold sibling.
 	for i := range rt.NumField() {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -458,6 +458,16 @@ func TestEncode_textMarshalerErrorUnwraps(t *testing.T) {
 	}
 }
 
+// A directly-constructed EncodeError with no underlying Err must not render a
+// dangling "field : <nil>" message. The encode path always sets a cause, but the
+// type is exported, so guard the empty-payload case — matching the DecodeError,
+// RequiredGroupError, and MissingNamedGroupsError siblings.
+func TestEncodeError_nilErrRendersCleanMessage(t *testing.T) {
+	if got, want := (&rx.EncodeError{}).Error(), "no encode error"; got != want {
+		t.Errorf("(&EncodeError{}).Error() = %q, want %q", got, want)
+	}
+}
+
 // ── Decoder.Encoder: derivation error paths ────────────────────────────────────
 
 // Non-invertible constructs outside a named capture have no single string to

--- a/regextra.go
+++ b/regextra.go
@@ -63,7 +63,7 @@ By use case:
 For one-shot extraction, [Unmarshal] does its reflect work per call. For repeated
 decode of the same shape (log parsers, request handlers, config readers), use
 [Compile] / [Decoder] — it caches the per-field plan and benchmarks at roughly
-half the time and half the allocations of [Unmarshal] on equivalent input.
+half the time and far fewer allocations than [Unmarshal] on equivalent input.
 [Decoder.Iter] further skips the slice allocation entirely for streaming
 consumers.
 

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -148,8 +148,9 @@ func (e *RequiredGroupError) Error() string {
 //   - Falls back to exact field name match with capture group name
 //   - Falls back to case-insensitive field name match (Unicode simple case folding)
 //   - Supports type conversion for string, bool, all int/uint widths,
-//     float32/float64, time.Time, time.Duration, and single-level pointers
-//     to any of these; types implementing [RegexUnmarshaler] convert themselves
+//     float32/float64, time.Time, time.Duration, and pointers (any depth)
+//     to any of these; types implementing [RegexUnmarshaler] or
+//     encoding.TextUnmarshaler convert themselves
 //   - Unexported fields are ignored
 //   - A group that did not participate in the match (e.g. an optional group),
 //     or that matched an empty span, leaves the field unchanged — unless the
@@ -163,7 +164,10 @@ func (e *RequiredGroupError) Error() string {
 //
 // Returns an error if:
 //   - v is not a pointer to a struct
-//   - Type conversion fails on a matched group
+//   - Type conversion fails on a matched group (a [DecodeError])
+//   - A `required` field's group produced no value (a [RequiredGroupError]): it
+//     did not participate in the match or matched an empty span, and no
+//     `default=` supplied a substitute
 //   - A matched field is a nested struct, slice, or map: these are not
 //     flattened, so a group bound to one yields an "unsupported field type"
 //     error (unless the type implements [RegexUnmarshaler] or
@@ -221,6 +225,12 @@ func Unmarshal(re *regexp.Regexp, target string, v any) error {
 // nil and sets the slice length to 0 — no match is data absence, not a failure.
 // See the package doc's "No-match behavior" section for the full cross-API
 // contract.
+//
+// Returns an error if v is not a pointer to a slice of structs, or if any match
+// fails to decode — a per-field conversion failure (a [DecodeError]) or a
+// `required` group that produced no value (a [RequiredGroupError]). The first
+// failing match stops the call and returns that error, prefixed with its match
+// index.
 //
 // Example:
 //

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -146,7 +146,7 @@ func (e *RequiredGroupError) Error() string {
 // Field mapping rules:
 //   - First checks the `regex:"groupname"` struct tag if provided (highest priority)
 //   - Falls back to exact field name match with capture group name
-//   - Falls back to case-insensitive field name match
+//   - Falls back to case-insensitive field name match (Unicode simple case folding)
 //   - Supports type conversion for string, bool, all int/uint widths,
 //     float32/float64, time.Time, time.Duration, and single-level pointers
 //     to any of these; types implementing [RegexUnmarshaler] convert themselves


### PR DESCRIPTION
## Summary

Public-contract accuracy & consistency audit over the exported surface
(`regextra.go`, `decoder.go`, `unmarshal.go`, `encoder.go`, `README.md`) before
the v2.0.0 tag. Corrects documentation/comment drift against observed behavior,
plus one small code fix bringing `EncodeError.Error()` in line with its sibling
error types. No API break — the only code change is a nil-guard on a zero-value
`EncodeError` (error-message wording is explicitly non-breaking per README
§Stability).

### Documentation drift fixes (README)

1. **`NamedGroups` duplicate-name semantics** (README): "only the last match is returned" → the last *participating* occurrence wins, matching the godoc and #127.
2. **`Unmarshal` time layouts** (README): reorder to RFC3339Nano-first to match `timeLayouts` (`unmarshal.go`), fixing the contradiction with the Encoder section.
3. **`Decoder` vs `Unmarshal` allocations** (README + `regextra.go` package doc): refreshed to current measurements — `Decoder.One` 2 allocs, `Unmarshal` 11 allocs (were documented as 3/6) — and dropped the stale "half the allocations" claim.
4. **`Decoder.Iter` vs `UnmarshalAll` performance** (README): the "~37% faster / ~50% fewer allocations" claim is obsolete now that `UnmarshalAll` was optimized (#108/#41: 608→114 allocs). Restated as roughly comparable throughput on full iteration, with Iter's real advantage repositioned as streaming / lower peak memory / lazy early-break.
5. **Field-matching terminology**: unify decode-side "case-insensitive" and encode-side "Unicode simple-fold" — both are `strings.EqualFold` — on one precise phrase.
6. **Error-prefix contract** (README): document the intended exception that `Compile` / `Decoder.Encoder()` construction-time errors carry the bare `regextra:` sentinel prefix (they wrap `ErrInvalidPattern` / `ErrInvalidStruct` / `ErrNotInvertible`), not a `regextra.<Entrypoint>:` prefix.

### Error-taxonomy & supported-type godoc fixes (public entrypoints)

Follow-up commit correcting godoc that under- or over-stated the runtime contract:

7. **Decode entrypoints omitted `*RequiredGroupError`** — `Decoder.One` / `Decoder.All` / `Decoder.Iter` (`decoder.go`) and `Unmarshal` / `UnmarshalAll` (`unmarshal.go`) framed the only failure as a per-field `*DecodeError`, but all five also return `*RequiredGroupError` (the `RequiredGroupError` type doc already lists all five). Now document both typed errors and mirror the bidirectional cross-refs.
8. **Encode docs omitted the nil-interface trigger** — `Encode`, `Decoder.Encoder()`'s closing note, and the `EncodeError` type doc listed only the nil-*pointer* runtime trigger; `encodeFieldValue` also returns an `EncodeError` for a nil *interface* field. Added alongside the nil-pointer case in all three.
9. **`Unmarshal` supported-types bullet** — "single-level pointers" → "pointers (any depth)" (`setFieldValue` recurses through indirection, so `**int` works), and added `encoding.TextUnmarshaler` next to `[RegexUnmarshaler]` as a self-converting type.
10. **`Compile` undeclared-group bullet too broad** — `buildDecodePlan` only errors when the group is undeclared *and* the field has no `default=`; noted the `default=` exception so the bullet matches the code.
11. **Dangling cross-ref in `Decoder.Encoder`** — its error bullet pointed at "`[Encoder]` for the supported set", but the `Encoder` type doc never enumerated the supported field types. Added an explicit supported-field-types list to the `Encoder` type doc so the cross-reference resolves.

### Code fix

12. **`EncodeError.Error()` nil-`Err` guard** — a zero-value `EncodeError{}` rendered `"field : <nil>"`. Its three siblings (`DecodeError`, `RequiredGroupError`, `MissingNamedGroupsError`) each guard their empty-payload case; added the matching guard returning `"no encode error"`, with a parallel `Error()` test.

### Measured numbers (Apple M4)

Sourced the updated perf claims (findings 3–4) from a fresh bench run:

| Benchmark | ns/op | allocs/op |
|---|---|---|
| `DecoderOne/simple` | ~255 | 2 |
| `Unmarshal/simpleThreeField` | ~540 | 11 |
| `DecoderIter/fullIteration` (100 lines) | ~28µs | ~205 |
| `UnmarshalAll/realisticLogCorpus` (100 lines) | ~26µs | ~114 |

Note on finding 4: the original claim was directionally wrong now (Iter is no longer faster or lower-alloc than `UnmarshalAll` on full iteration), not merely stale in magnitude — so it was rewritten to the measured reality and hedged as hardware-dependent rather than re-quoted against an obsolete baseline.

### Deferred

- **"regextra is at v1" language** (README §Stability, `regextra.go` package doc) — the §Stability v2 bump is owned by #131; left untouched to avoid double-editing.

## Test plan

- [x] `go test -race ./...` — pass
- [x] `go vet ./...` — clean
- [x] `gofmt -s -l .` — clean
- [x] `golangci-lint run` — 0 issues
- [x] Benchmarks re-run to source the updated numbers (Apple M4)

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how named groups are resolved when the same name appears more than once.
  * Expanded decoding and encoding docs to better explain field matching, type conversion, nil handling, and error behavior.
  * Updated performance notes and benchmark comparisons in the package docs.
  * Improved examples of streaming decode behavior, including how iteration continues after individual failures.

* **Bug Fixes**
  * Fixed the error message for a no-error state so it now shows a consistent, clearer message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->