### PR TITLE
chore(docs): remove retired Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 # regextra
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/jecoms/regextra/v2.svg)](https://pkg.go.dev/github.com/jecoms/regextra/v2)
-[![Go Report Card](https://goreportcard.com/badge/github.com/jecoms/regextra/v2)](https://goreportcard.com/report/github.com/jecoms/regextra/v2)
 [![Tests](https://github.com/jecoms/regextra/actions/workflows/test.yml/badge.svg)](https://github.com/jecoms/regextra/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
## Summary

- Removes the Go Report Card badge from the README — the service has been retired and the badge links to a dead report

## Notes

golangci-lint (the tool goreportcard.com recommends as a replacement) is already used in CI via the `golangci/golangci-lint-action` step in `test.yml`. The existing **Tests** badge already reflects its pass/fail status, so no new badge is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)