### PR TITLE
docs: fix post-v2.0.0 version drift across package doc, README, CONTRIBUTING, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [2.0.1] - 2026-07-02
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thank you for your interest in contributing! This guide provides essential infor
 ## Development Setup
 
 ### Requirements
-- **Go 1.22 or later** (currently targeting Go 1.24)
+- **Go 1.24 or later**
 - golangci-lint for linting
 - Git for version control
 
@@ -74,7 +74,8 @@ cp CLAUDE.md.example CLAUDE.md
   next to its source and test). Route each `Test*`/`Benchmark*` to the sibling
   file of the source it exercises, by function-name prefix (`TestUnmarshal*`,
   `BenchmarkUnmarshal*` → `unmarshal_*`; `TestCompile*`/`TestDecoder*` →
-  `decoder_*`; `TestNamedGroups*`/`TestFindNamed*`/`TestReplace*`/
+  `decoder_*`; `TestEncode*`/`TestEncoder*`/`BenchmarkEncode*` → `encoder_*`;
+  `TestNamedGroups*`/`TestFindNamed*`/`TestReplace*`/
   `TestValidate*` → `regextra_*`).
 - **Do not add topical test files** (one per feature, bug fix, or issue). That
   habit is what fragmented the suite; a new test belongs in the existing
@@ -183,6 +184,9 @@ regextra/
 ├── decoder.go             # Compile/MustCompile + Decoder[T] (One/All/Iter)
 ├── decoder_test.go        # tests for decoder.go
 ├── decoder_bench_test.go  # benchmarks for decoder.go
+├── encoder.go             # Decoder.Encoder + Encoder[T] (pattern-inverting encode)
+├── encoder_test.go        # tests for encoder.go
+├── encoder_bench_test.go  # benchmarks for encoder.go
 ├── bench_internal_test.go # package-internal benchmark (touches unexported code)
 ├── bench_sanity_test.go   # asserts the shared benchmark fixtures stay representative
 ├── README.md              # Public API documentation
@@ -195,7 +199,7 @@ regextra/
 └── .github/
     └── workflows/
         ├── test.yml     # CI: tests, coverage, linting
-        └── release.yml  # CD: automated releases
+        └── auto-tag.yml # CD: automated releases
 ```
 
 ## Testing Guidelines
@@ -216,7 +220,7 @@ go test -bench=. -benchmem
 ```
 
 ### Test Coverage Expectations
-- Aim for coverage: >92% (enforced by the CI coverage gate in `.github/workflows/test.yml`)
+- Coverage: CI fails below 92% (gate in `.github/workflows/test.yml`); the suite's real baseline is ~97% — keep it there, don't target the floor
 - All public APIs must be tested
 - Critical error paths must be covered
 - Edge cases: nil pointers, empty inputs, no matches
@@ -239,8 +243,8 @@ go test -bench=. -benchmem
   (`Closes #NN` / `Fixes #NN`) in the description so it auto-closes on merge
 - **Update tests**: Include test coverage for changes
 - **Breaking changes**: A breaking change **cannot ship in a minor or patch
-  release** — it must be deferred to the next major version (`v2.0.0`) and
-  called out as breaking. `regextra` is at v1 and follows strict SemVer; see
+  release** — it must be deferred to the next major version (`v3.0.0`) and
+  called out as breaking. `regextra` is at v2 and follows strict SemVer; see
   [README §Stability](./README.md#stability) for the precise definition of what
   counts as breaking (and what doesn't). When a breaking change is in scope for
   the next major, mark the commit/PR title with `!` (see the [Commit Message

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,8 @@ cp CLAUDE.md.example CLAUDE.md
   next to its source and test). Route each `Test*`/`Benchmark*` to the sibling
   file of the source it exercises, by function-name prefix (`TestUnmarshal*`,
   `BenchmarkUnmarshal*` → `unmarshal_*`; `TestCompile*`/`TestDecoder*` →
-  `decoder_*`; `TestEncode*`/`TestEncoder*`/`BenchmarkEncode*` → `encoder_*`;
+  `decoder_*`; `TestEncode*`/`TestEncoder*`/`BenchmarkEncode*`/
+  `BenchmarkDeriveEncoder*` → `encoder_*`;
   `TestNamedGroups*`/`TestFindNamed*`/`TestReplace*`/
   `TestValidate*` → `regextra_*`).
 - **Do not add topical test files** (one per feature, bug fix, or issue). That

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ type LogLine struct {
 
 **Excluding a field:** `regex:"-"` excludes a field entirely — it is never populated, even if a declared group happens to share the field's name. This matches the `-` convention in `encoding/json`, `encoding/xml`, and `gopkg.in/yaml`. It differs from an absent tag (`regex:""`), which falls back to matching the field's own name against a group. Only the bare `-` excludes; a leading `-` followed by options (e.g. `regex:"-,default=x"`) parses `-` as the group name, which matches no group since regexp group names are Go identifiers.
 
-**Forward-compat rules (v1 contract):**
+**Forward-compat rules (stable since v1):**
 
 - **Unknown `key=value` pairs are preserved, not rejected.** Adding a new option key in a future minor release is not a breaking change. Don't rely on the parser rejecting unknown keys — pin a minor version range if you need a specific recognized set.
 - **Lone tokens (no `=`) other than the recognized `required` flag are silently ignored.** Today, `regex:"name,foo"` parses as `(name="name")` — the `foo` token is dropped. The slot is reserved for future flag-style options (`required` claimed the first one — see the options table above); a later minor may start recognizing further lone tokens. Don't rely on an unrecognized lone token remaining inert.

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ type LogLine struct {
 
 **Excluding a field:** `regex:"-"` excludes a field entirely — it is never populated, even if a declared group happens to share the field's name. This matches the `-` convention in `encoding/json`, `encoding/xml`, and `gopkg.in/yaml`. It differs from an absent tag (`regex:""`), which falls back to matching the field's own name against a group. Only the bare `-` excludes; a leading `-` followed by options (e.g. `regex:"-,default=x"`) parses `-` as the group name, which matches no group since regexp group names are Go identifiers.
 
-**Forward-compat rules (stable since v1):**
+**Forward-compat rules (part of the stability contract since v1):**
 
 - **Unknown `key=value` pairs are preserved, not rejected.** Adding a new option key in a future minor release is not a breaking change. Don't rely on the parser rejecting unknown keys — pin a minor version range if you need a specific recognized set.
 - **Lone tokens (no `=`) other than the recognized `required` flag are silently ignored.** Today, `regex:"name,foo"` parses as `(name="name")` — the `foo` token is dropped. The slot is reserved for future flag-style options (`required` claimed the first one — see the options table above); a later minor may start recognizing further lone tokens. Don't rely on an unrecognized lone token remaining inert.

--- a/regextra.go
+++ b/regextra.go
@@ -170,8 +170,8 @@ Only the bare `-` tag excludes. A leading `-` followed by options
 (e.g. `regex:"-,default=x"`) parses `-` as the group name, which matches no
 group since regexp group names are Go identifiers.
 
-Two forward-compatibility rules in the tag parser are part of the stability
-contract since v1:
+Two forward-compatibility rules in the tag parser are part of the
+stability contract since v1:
 
   - Unknown key=value pairs are preserved, not rejected. The parser stores
     every key=value pair regardless of whether the key is currently

--- a/regextra.go
+++ b/regextra.go
@@ -170,7 +170,8 @@ Only the bare `-` tag excludes. A leading `-` followed by options
 (e.g. `regex:"-,default=x"`) parses `-` as the group name, which matches no
 group since regexp group names are Go identifiers.
 
-Two forward-compatibility rules in the tag parser are part of the v1 contract:
+Two forward-compatibility rules in the tag parser are part of the stability
+contract since v1:
 
   - Unknown key=value pairs are preserved, not rejected. The parser stores
     every key=value pair regardless of whether the key is currently
@@ -196,7 +197,7 @@ grammar) or a recognized flag token (claiming a previously-ignored slot).
 
 # Stability
 
-regextra is at v1 and follows strict SemVer. Patch releases are fixes only.
+regextra is at v2 and follows strict SemVer. Patch releases are fixes only.
 Minor releases add features without breaking changes. Breaking changes ship
 in the next major version, never in a minor or patch. See the README's
 Stability section for the precise contract, including what does and

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -355,8 +355,8 @@ func UnmarshalAll(re *regexp.Regexp, target string, v any) error {
 // value. It is the first recognized lone-token flag (the slot the forward-compat
 // rules below reserved).
 //
-// Forward-compat rules (locked in since v1 — see the package doc's
-// "Tag grammar" section for the full statement and rationale):
+// Forward-compat rules (part of the stability contract since v1 — see the
+// package doc's "Tag grammar" section for the full statement and rationale):
 //   - Unknown key=value pairs are preserved in the returned map so future
 //     option additions don't need to touch the parser; adding a new option
 //     key is therefore not a breaking change.

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -355,7 +355,7 @@ func UnmarshalAll(re *regexp.Regexp, target string, v any) error {
 // value. It is the first recognized lone-token flag (the slot the forward-compat
 // rules below reserved).
 //
-// Forward-compat rules (locked in as v1 contract — see the package doc's
+// Forward-compat rules (locked in since v1 — see the package doc's
 // "Tag grammar" section for the full statement and rationale):
 //   - Unknown key=value pairs are preserved in the returned map so future
 //     option additions don't need to touch the parser; adding a new option

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1633,7 +1633,8 @@ func TestUnmarshal_dashWithOptionsIsNotExcluded(t *testing.T) {
 }
 
 // Issue #113: pin the two tag-grammar forward-compatibility rules that the
-// package doc (regextra.go "Tag grammar") declares part of the v1 contract,
+// package doc (regextra.go "Tag grammar") declares part of the stability
+// contract since v1,
 // exercised through the public Unmarshal/Decoder surface rather than the
 // unexported parser:
 //

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1633,8 +1633,8 @@ func TestUnmarshal_dashWithOptionsIsNotExcluded(t *testing.T) {
 }
 
 // Issue #113: pin the two tag-grammar forward-compatibility rules that the
-// package doc (regextra.go "Tag grammar") declares part of the stability
-// contract since v1,
+// package doc (regextra.go "Tag grammar") declares part of the
+// stability contract since v1,
 // exercised through the public Unmarshal/Decoder surface rather than the
 // unexported parser:
 //


### PR DESCRIPTION
## Summary
- Package doc (`regextra.go`) §Stability now says the module is at v2; tag-grammar and forward-compat wording in `regextra.go`, `README.md`, `unmarshal.go` (and the test comment quoting it) changes from "v1 contract" to "stability contract since v1".
- `CONTRIBUTING.md`: Go floor now matches `go.mod` (1.24), breaking changes defer to `v3.0.0` / "at v2", project tree gains `encoder.go`/`encoder_test.go`/`encoder_bench_test.go` and swaps deleted `release.yml` for `auto-tag.yml`, test-routing list adds `TestEncode*`/`TestEncoder*`/`BenchmarkEncode*` → `encoder_*`, and the coverage note now states the 92% CI floor vs the ~97% real baseline.
- `CHANGELOG.md` regains the `## [Unreleased]` heading that CONTRIBUTING instructs contributors to file entries under.

Docs-only; no behavior change. Historical CHANGELOG entries that mention `release.yml` / "v1 contract" are release notes and intentionally left untouched.

## Test plan
- [x] `grep -rn "at v1\|v1 contract\|Go 1.22\|release.yml" *.go *.md` — only historical CHANGELOG entries remain
- [x] `go build ./... && go vet ./... && go test ./...` pass; `gofmt -s -l .` clean
- [x] CONTRIBUTING tree verified against `ls` and `.github/workflows/`

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an **Unreleased** section to the changelog.
  * Updated contribution guidance, including supported Go versions, testing, coverage, project structure, and breaking-change policy.
  * Clarified forward-compatibility and stability commitments in the README and package documentation.
  * Updated the documented package version from v1 to v2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->