### PR TITLE
docs: restructure README as a front page; make godoc the canonical reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **README restructured as a front page; the package documentation on pkg.go.dev is now the canonical per-symbol reference.** The README's per-function reference section was removed in favor of a one-row-per-symbol API table linking pkg.go.dev anchors; README-only contract text (conversion precedence, `time.Time` layout fallbacks, `Iter` streaming guidance) was ported into godoc before deletion. ([#194](https://github.com/Jecoms/regextra/issues/194), [#208](https://github.com/Jecoms/regextra/pull/208))
+
 ## [2.0.1] - 2026-07-02
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,9 @@ cp CLAUDE.md.example CLAUDE.md
   and how to use it (the contract a caller relies on), not how it's implemented
   internally
 - Include usage examples in the godoc
-- Update README.md when adding new public APIs
+- When adding a new public API, add a row to the README's API table (linking
+  its pkg.go.dev anchor) — the godoc comment is the full reference; the README
+  is a front page and does not duplicate per-symbol contracts
 - Add example tests that demonstrate usage
 - **A comment describes the code as it stands now, never a past version of it.**
   When you refactor, don't leave the old implementation behind as a comment
@@ -190,7 +192,7 @@ regextra/
 ├── encoder_bench_test.go  # benchmarks for encoder.go
 ├── bench_internal_test.go # package-internal benchmark (touches unexported code)
 ├── bench_sanity_test.go   # asserts the shared benchmark fixtures stay representative
-├── README.md              # Public API documentation
+├── README.md              # Front page: install, usage tour, API table, stability policy
 ├── AGENTS.md.example      # Template for a personal (gitignored) agent guide
 ├── CLAUDE.md.example      # Template for a personal (gitignored) Claude Code guide
 ├── CONTRIBUTING.md         # This file
@@ -232,7 +234,8 @@ go test -bench=. -benchmem
 1. **Run tests locally**: `go test -v -race ./...`
 2. **Run linter**: `golangci-lint run`
 3. **Check formatting**: `gofmt -s -l .`
-4. **Update documentation**: Add examples and update README if needed
+4. **Update documentation**: Write the godoc contract and examples; for a new
+   public API, add a row to the README's API table
 5. **Add a CHANGELOG entry**: for a feature or a change to existing behavior, add an entry under `## [Unreleased]` in `CHANGELOG.md` (see [Changelog](#changelog))
 6. **Check benchmarks**: for hot-path or feature changes, confirm the relevant `*_bench_test.go` benchmarks hold or improve (or justify the regression)
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 Extensions to Go's regexp package for easier handling of named capture groups:
 name-based extraction, `json.Unmarshal`-style decoding into structs, a typed
 compiled decoder for hot paths, and a derived encoder that renders structs back
-into strings. No wrapper types — every function works directly with
-`*regexp.Regexp` — and no dependencies outside the standard library.
+into strings. The simple functions work directly with `*regexp.Regexp` — no
+wrapper types required — and there are no dependencies outside the standard
+library.
 
 The full per-symbol reference lives in the
 [package documentation on pkg.go.dev](https://pkg.go.dev/github.com/jecoms/regextra/v2);
@@ -78,7 +79,8 @@ func main() {
 | [`UnmarshalAll`](https://pkg.go.dev/github.com/jecoms/regextra/v2#UnmarshalAll) | Decode every match into a slice of structs |
 | [`Compile`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Compile) / [`MustCompile`](https://pkg.go.dev/github.com/jecoms/regextra/v2#MustCompile) | Build a [`Decoder[T]`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Decoder) with strict upfront validation — compile once, decode many times |
 | [`Decoder.One`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Decoder.One) / [`Decoder.All`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Decoder.All) / [`Decoder.Iter`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Decoder.Iter) | Typed decode of the first match / every match / a lazy match stream |
-| [`Decoder.Encoder`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Decoder.Encoder) | Derive an [`Encoder[T]`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Encoder) — the typed inverse that renders a struct back into a string by inverting the decoder's own pattern |
+| [`Decoder.Pattern`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Decoder.Pattern) / [`Decoder.Regexp`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Decoder.Regexp) | Accessors for the decoder's pattern source and its compiled `*regexp.Regexp` |
+| [`Decoder.Encoder`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Decoder.Encoder) / [`Encoder.Encode`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Encoder.Encode) | Derive an [`Encoder[T]`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Encoder) — the typed inverse built by inverting the decoder's own pattern — and render a struct back into a string |
 | [`RegexUnmarshaler`](https://pkg.go.dev/github.com/jecoms/regextra/v2#RegexUnmarshaler) / [`RegexMarshaler`](https://pkg.go.dev/github.com/jecoms/regextra/v2#RegexMarshaler) | Extension points for caller-defined types on the decode / encode side |
 | [`ErrNoMatch`](https://pkg.go.dev/github.com/jecoms/regextra/v2#ErrNoMatch), [`ErrInvalidPattern`](https://pkg.go.dev/github.com/jecoms/regextra/v2#ErrInvalidPattern), [`ErrInvalidStruct`](https://pkg.go.dev/github.com/jecoms/regextra/v2#ErrInvalidStruct), [`ErrNotInvertible`](https://pkg.go.dev/github.com/jecoms/regextra/v2#ErrNotInvertible) | Sentinel errors — compare with `errors.Is` |
 | [`DecodeError`](https://pkg.go.dev/github.com/jecoms/regextra/v2#DecodeError), [`EncodeError`](https://pkg.go.dev/github.com/jecoms/regextra/v2#EncodeError), [`RequiredGroupError`](https://pkg.go.dev/github.com/jecoms/regextra/v2#RequiredGroupError), [`MissingNamedGroupsError`](https://pkg.go.dev/github.com/jecoms/regextra/v2#MissingNamedGroupsError) | Typed errors — recover with `errors.As` |

--- a/README.md
+++ b/README.md
@@ -1,43 +1,24 @@
-
-
 # regextra
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/jecoms/regextra/v2.svg)](https://pkg.go.dev/github.com/jecoms/regextra/v2)
 [![Tests](https://github.com/jecoms/regextra/actions/workflows/test.yml/badge.svg)](https://github.com/jecoms/regextra/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Extensions to Go's regexp package for easier handling of named capture groups.
+Extensions to Go's regexp package for easier handling of named capture groups:
+name-based extraction, `json.Unmarshal`-style decoding into structs, a typed
+compiled decoder for hot paths, and a derived encoder that renders structs back
+into strings. No wrapper types — every function works directly with
+`*regexp.Regexp` — and no dependencies outside the standard library.
+
+The full per-symbol reference lives in the
+[package documentation on pkg.go.dev](https://pkg.go.dev/github.com/jecoms/regextra/v2);
+the table below links each symbol to it.
 
 ## Installation
 
 ```bash
 go get github.com/jecoms/regextra/v2@latest
 ```
-
-## Stability
-
-`regextra` is at v2 and follows strict SemVer. Import it at the `/v2` module path (`github.com/jecoms/regextra/v2`); the v1 line is frozen at the `v1.x` tags.
-
-- Breaking changes ship in the next major version (`v3.0.0`), never in a minor or patch.
-- Minor releases (`v2.x.0`) add features.
-- Patch releases (`v2.x.y`) are fixes only.
-
-v2.0.0 collects the behavior changes made since v1.0.0; see [CHANGELOG.md](./CHANGELOG.md) for the exhaustive list, with every breaking entry marked.
-
-The forward look is tracked in the [issue tracker](https://github.com/Jecoms/regextra/issues).
-
-**What counts as breaking**
-
-- Removing or renaming an exported symbol.
-- Changing the signature of an exported function or method.
-- Changing observable behavior of an existing call (e.g. a previously-returning call now returns an error).
-
-**What does *not* count as breaking**
-
-- Adding a new exported function, type, or method.
-- Adding a new option to the `regex:"..."` struct tag grammar.
-- Accepting additional field types in `Unmarshal` / `UnmarshalAll` / `Decoder`.
-- Changing the wording of error messages. Do not pattern-match on `err.Error()` strings; compare against the exported sentinels (e.g. `regextra.ErrNoMatch`, `regextra.ErrInvalidPattern`, `regextra.ErrInvalidStruct` with `errors.Is`) or recover the typed `*regextra.DecodeError` with `errors.As` instead.
 
 ## Usage
 
@@ -81,464 +62,51 @@ func main() {
 
 ## API
 
-### `FindNamed(re *regexp.Regexp, target, groupName string) (string, bool)`
-
-Extract a single named capture group from the target string.
-
-Returns the matched value and `true` if found, or empty string and `false` if not found.
-
-```go
-re := regexp.MustCompile(`(?P<price>\$\d+\.\d{2})`)
-price, ok := regextra.FindNamed(re, "Total: $19.99", "price")
-// price = "$19.99", ok = true
-```
-
-### `FindAllNamed(re *regexp.Regexp, target, groupName string) []string`
-
-Extract every value of a single named capture group across all matches.
-
-Returns `nil` if the group name is not declared on the regex; an empty slice if the group is declared but the regex has no matches.
-
-```go
-re := regexp.MustCompile(`(?P<word>\S+)`)
-words := regextra.FindAllNamed(re, "alpha beta gamma", "word")
-// words = []string{"alpha", "beta", "gamma"}
-```
-
-For a single match, prefer `FindNamed`. To pull every named group from one match — including patterns where the same name is declared more than once — use `AllNamedGroups`. Despite the "All" prefix, `AllNamedGroups` operates on a single match; it is not the all-matches counterpart of `FindAllNamed`.
-
-### `NamedGroups(re *regexp.Regexp, target string) map[string]string`
-
-Extract all named capture groups as a map. If a group name appears multiple times (e.g. across alternation branches), the value of the last occurrence that participated in the match wins; a non-participating occurrence never overwrites a participating one.
-
-Returns an empty map if no match is found.
-
-```go
-re := regexp.MustCompile(`(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})`)
-groups := regextra.NamedGroups(re, "Date: 2025-10-04")
-// groups = map[string]string{"year": "2025", "month": "10", "day": "04"}
-```
-
-### `AllNamedGroups(re *regexp.Regexp, target string) map[string][]string`
-
-Operates on a **single match** and returns every value of every named capture group, keyed by group name. Each value is a slice because Go's `regexp` allows the same group name to appear more than once in a pattern — `AllNamedGroups` preserves every occurrence in left-to-right order. Groups that appear once still get a one-element slice.
-
-The leading "All" refers to **all named groups in one match** — not to all matches across the target. Use `FindAllNamed` to collect a single named group across every match, or `NamedGroupsPerMatch` to collect every named group across every match as one map per match (`[]map[string]string`); the unmarshal path (`UnmarshalAll`, `Decoder.All`, `Decoder.Iter`) is the typed equivalent.
-
-Returns an empty map if no match is found.
-
-```go
-// Duplicate group names — the use case this function exists for:
-re := regexp.MustCompile(`(?P<word>\w+) (?P<word>\w+) (?P<word>\w+)`)
-allGroups := regextra.AllNamedGroups(re, "one two three")
-// allGroups = map[string][]string{"word": []string{"one", "two", "three"}}
-
-// Distinct group names — each slice has one element:
-re = regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
-allGroups = regextra.AllNamedGroups(re, "Alice 30")
-// allGroups = map[string][]string{"name": []string{"Alice"}, "age": []string{"30"}}
-```
-
-### `NamedGroupsPerMatch(re *regexp.Regexp, target string) []map[string]string`
-
-The every-match counterpart to `NamedGroups`: returns one map of named-group values per match of `re` in `target`, in match order. Each map follows the same per-match semantics as `NamedGroups` — every declared group is present, a group that did not participate in that match is mapped to `""`, and a reused group name resolves to the last participating occurrence in that match.
-
-Returns an empty (non-nil) slice if there are no matches. For the typed equivalent that decodes each match into a struct, use `UnmarshalAll` / `Decoder.All`.
-
-```go
-re := regexp.MustCompile(`(?P<key>\w+)=(?P<value>\w+)`)
-all := regextra.NamedGroupsPerMatch(re, "a=1 b=2")
-// all = []map[string]string{{"key": "a", "value": "1"}, {"key": "b", "value": "2"}}
-```
-
-### `NamedGroupsPerMatchSeq(re *regexp.Regexp, target string) iter.Seq[map[string]string]`
-
-The lazy, range-over-func (Go 1.23+) form of `NamedGroupsPerMatch`: yields one named-group map per match, in match order, without building the intermediate slice. Stopping the range early (`break`) stops the iteration. On no match, the iterator yields zero times. For the typed streaming equivalent, use `Decoder.Iter`.
-
-```go
-re := regexp.MustCompile(`(?P<key>\w+)=(?P<value>\w+)`)
-for m := range regextra.NamedGroupsPerMatchSeq(re, "a=1 b=2") {
-    fmt.Println(m["key"], m["value"])
-}
-// a 1
-// b 2
-```
-
-### `Replace(re *regexp.Regexp, target string, replacements map[string]string) string`
-
-Substitute the matched span of each named capture group with the value from `replacements`, leaving non-matching text and any groups absent from the map unchanged. `Replace` operates on every match of `re`, in order.
-
-```go
-re := regexp.MustCompile(`(?P<user>\w+)@(?P<domain>[\w.]+)`)
-out := regextra.Replace(re, "alice@example.com bob@other.org", map[string]string{
-    "domain": "redacted",
-})
-// out = "alice@redacted bob@redacted"
-```
-
-### `ReplaceFirst(re *regexp.Regexp, target string, replacements map[string]string) string`
-
-Like `Replace`, but substitutes named-group spans only within the **first** match of `re`; every later match, and all text outside the first match, passes through byte-for-byte unchanged. Within that first match it follows `Replace`'s rules exactly (groups absent from the map pass through, non-participating groups are skipped, outermost span wins on overlap). On no match, the target is returned unchanged.
-
-```go
-re := regexp.MustCompile(`(?P<user>\w+)@(?P<domain>[\w.]+)`)
-out := regextra.ReplaceFirst(re, "alice@example.com bob@other.org", map[string]string{
-    "domain": "redacted",
-})
-// out = "alice@redacted bob@other.org"
-```
-
-### `ReplaceFunc(re *regexp.Regexp, target string, fn func(group, match string) string) string`
-
-Like `Replace`, but the replacement for each named-group span is computed by a callback over the matched value instead of looked up in a static map. Use it when the substitution depends on what matched — redaction, normalization, and similar. `fn` is called once per substituted named span, left to right, with the group's name and matched text; return the match verbatim to leave a group unchanged. On no match the target is returned unchanged and `fn` is never called. Passing a nil `fn` is a programmer error and panics on the first match, mirroring the standard library's `Regexp.ReplaceAllStringFunc`.
-
-When named groups overlap (nesting), the outermost group whose span is encountered first wins and `fn` is not called for inner groups inside an already-substituted span — the same overlap rule as `Replace`.
-
-```go
-// Mask all but the last four digits of a captured card number:
-re := regexp.MustCompile(`(?P<card>\d{12,19})`)
-out := regextra.ReplaceFunc(re, "card 4111111111111111 ok", func(group, match string) string {
-    return strings.Repeat("*", len(match)-4) + match[len(match)-4:]
-})
-// out = "card ************1111 ok"
-```
-
-### `Validate(re *regexp.Regexp, required ...string) error`
-
-Returns an error listing every required group name that is not declared on `re`. Use it for init-time assertions in services that compile patterns once: catch typos at startup rather than at the first (mis-)matched request.
-
-```go
-re := regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
-
-if err := regextra.Validate(re, "name", "age", "ssn"); err != nil {
-    // err: regextra.Validate: missing named groups: ssn
-}
-```
-
-On failure `Validate` returns an `errors.As`-able `*regextra.MissingNamedGroupsError` whose `Missing` field carries the absent group names (in the order passed), so you can branch on the missing set without parsing the message — see [§Stability](#stability) on comparing types, not strings:
-
-```go
-var ve *regextra.MissingNamedGroupsError
-if errors.As(err, &ve) {
-    // ve.Missing == []string{"ssn"}
-}
-```
-
-### `Unmarshal(re *regexp.Regexp, target string, v any) error`
-
-Unmarshal regex matches into a struct with automatic type conversion. Similar to `json.Unmarshal`, but for regex patterns.
-
-**Supported field types:** `string`, `int`, `int8`, `int16`, `int32`, `int64`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `float32`, `float64`, `bool`, `time.Time`, `time.Duration`. Pointer-to-any-of-the-above is also supported — nil pointers are allocated, non-nil pointers are reused (pointee overwritten). For `time.Time`, several common layouts are tried in order (RFC3339Nano, RFC3339, `2006-01-02 15:04:05`, `2006-01-02`, `15:04:05`); `time.Duration` is parsed via `time.ParseDuration`. Any field whose type (or pointer-to-type) implements [`encoding.TextUnmarshaler`](https://pkg.go.dev/encoding#TextUnmarshaler) is also supported out of the box — e.g. `netip.Addr`, `math/big.Int`, `log/slog.Level`, `github.com/google/uuid.UUID` — by calling its `UnmarshalText` with the matched value. For caller-defined types, implement [`RegexUnmarshaler`](#regexunmarshaler-interface).
-
-**Field mapping priority:**
-1. Struct tag `regex:"groupname"` if provided (highest priority)
-2. Exact field name match with capture group name
-3. Case-insensitive field name match (Unicode simple case folding)
-- Unexported fields are ignored
-
-Returns an error if the target is not a pointer to a struct, or if type conversion fails.
-
-```go
-type Person struct {
-    Name string
-    Age  int
-}
-
-re := regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
-var person Person
-err := regextra.Unmarshal(re, "Alice is 30", &person)
-// person.Name = "Alice", person.Age = 30
-```
-
-**With struct tags:**
-
-```go
-type Email struct {
-    Username string `regex:"user"`
-    Domain   string `regex:"domain"`
-}
-
-re := regexp.MustCompile(`(?P<user>\w+)@(?P<domain>[\w.]+)`)
-var email Email
-err := regextra.Unmarshal(re, "alice@example.com", &email)
-// email.Username = "alice", email.Domain = "example.com"
-```
-
-**Tag options:**
-
-The `regex:"..."` tag accepts comma-separated `key=value` options after the group name:
-
-| Option | Applies to | Effect |
-|---|---|---|
-| `default=<value>` | Any field type | Substituted when the named group is not declared on the regex or its match is empty. The default goes through the same type conversion as a real match. |
-| `layout=<go-time-layout>` | `time.Time` only | Use the supplied [time.Parse layout](https://pkg.go.dev/time#Parse) exclusively, instead of the default fallback list. Lets you pin the parser to (e.g.) Apache, syslog, or any other non-RFC3339 timestamp shape. |
-| `required` *(flag)* | Any field type | Decode fails with an `errors.As`-able `*RequiredGroupError` when the named group does not participate in the match or matches an empty span and no `default=` supplies a value. A `default=` satisfies the requirement. Lets a field declare its mandatory-ness inline instead of a separate `Validate` pass. |
-
-```go
-type LogLine struct {
-    TS    time.Time `regex:"ts,layout=02/Jan/2006:15:04:05 -0700"`
-    Level string    `regex:"level,default=info"`
-    User  string    `regex:"user,required"`
-}
-```
-
-**Excluding a field:** `regex:"-"` excludes a field entirely — it is never populated, even if a declared group happens to share the field's name. This matches the `-` convention in `encoding/json`, `encoding/xml`, and `gopkg.in/yaml`. It differs from an absent tag (`regex:""`), which falls back to matching the field's own name against a group. Only the bare `-` excludes; a leading `-` followed by options (e.g. `regex:"-,default=x"`) parses `-` as the group name, which matches no group since regexp group names are Go identifiers.
-
-**Forward-compat rules (part of the stability contract since v1):**
-
-- **Unknown `key=value` pairs are preserved, not rejected.** Adding a new option key in a future minor release is not a breaking change. Don't rely on the parser rejecting unknown keys — pin a minor version range if you need a specific recognized set.
-- **Lone tokens (no `=`) other than the recognized `required` flag are silently ignored.** Today, `regex:"name,foo"` parses as `(name="name")` — the `foo` token is dropped. The slot is reserved for future flag-style options (`required` claimed the first one — see the options table above); a later minor may start recognizing further lone tokens. Don't rely on an unrecognized lone token remaining inert.
-
-See the package doc's **Tag grammar** section on [pkg.go.dev](https://pkg.go.dev/github.com/jecoms/regextra/v2) for the canonical statement.
-
-### `RegexUnmarshaler` interface
-
-Mirror of `encoding.TextUnmarshaler` for regextra's unmarshal path. When a destination field's pointer type satisfies this interface, `Unmarshal` (and `UnmarshalAll`) call `UnmarshalRegex` with the matched group value instead of running the built-in string/int/uint/float/bool conversion.
-
-```go
-type RegexUnmarshaler interface {
-    UnmarshalRegex(value string) error
-}
-```
-
-The extension point for caller-defined types the built-in type switch can't handle (URLs, enums, big numbers, IP addresses, etc.).
-
-**Conversion precedence.** For each field, `Unmarshal` tries in order: (1) `RegexUnmarshaler` — the package-specific hook always wins; (2) the `time.Time` / `time.Duration` special-cases (so the multi-layout fallback and `layout` tag option are preserved — `time.Time` happens to implement `encoding.TextUnmarshaler` but its `UnmarshalText` only accepts RFC3339, so it is *not* routed through the fallback); (3) `encoding.TextUnmarshaler` — for any other type that implements it; (4) the built-in string/int/uint/float/bool conversion. So a type implementing both `RegexUnmarshaler` and `encoding.TextUnmarshaler` dispatches on `UnmarshalRegex`.
-
-```go
-type Status int
-
-const (
-    StatusUnknown Status = iota
-    StatusOpen
-    StatusClosed
-)
-
-func (s *Status) UnmarshalRegex(value string) error {
-    switch value {
-    case "open":   *s = StatusOpen
-    case "closed": *s = StatusClosed
-    default:       return fmt.Errorf("unknown status %q", value)
-    }
-    return nil
-}
-
-type Issue struct {
-    ID    int    `regex:"id"`
-    State Status `regex:"state"`
-}
-
-re := regexp.MustCompile(`#(?P<id>\d+) \[(?P<state>\w+)\]`)
-var issue Issue
-regextra.Unmarshal(re, "#42 [open]", &issue)
-// issue = Issue{ID: 42, State: StatusOpen}
-```
-
-### `UnmarshalAll(re *regexp.Regexp, target string, v any) error`
-
-UnmarshalAll finds all occurrences of the regex pattern in the target string and unmarshals them into a slice of structs. The slice is cleared before populating.
-
-v must be a pointer to a slice of structs. If no matches are found, the slice will be empty.
-
-**Supported field types:** Same as `Unmarshal`
-
-**Field mapping priority:** Same as `Unmarshal`
-
-```go
-type Person struct {
-    Name string
-    Age  int
-}
-
-re := regexp.MustCompile(`(?P<name>\w+) is (?P<age>\d+)`)
-var people []Person
-err := regextra.UnmarshalAll(re, "Alice is 30 and Bob is 25", &people)
-// people = []Person{
-//     {Name: "Alice", Age: 30},
-//     {Name: "Bob", Age: 25},
-// }
-```
-
-### `Compile[T any](pattern string) (*Decoder[T], error)` / `MustCompile[T any](pattern string) *Decoder[T]`
-
-Typed, regex-bound unmarshaler that carries the precomputed reflect plan for `T`'s fields. **Compile once, decode many times.** (`Unmarshal` / `UnmarshalAll` cache their decode plan too — built on first use of a (pattern, struct type) pair, kept for the life of the process — so the `Decoder`'s remaining edge is skipping the per-call cache lookup, plus the strict upfront validation below.)
-
-```go
-type Person struct {
-    Name string `regex:"name"`
-    Age  int    `regex:"age"`
-}
-
-// Compile validates pattern + struct tags upfront.
-var personDecoder = regextra.MustCompile[Person](`(?P<name>\w+) is (?P<age>\d+)`)
-
-// Hot path — no reflect per call.
-p, err := personDecoder.One("Alice is 30")
-// p = Person{Name: "Alice", Age: 30}, err = nil
-
-people, _ := personDecoder.All("Alice is 30 and Bob is 25")
-// people = []Person{{"Alice", 30}, {"Bob", 25}}
-```
-
-**vs `Unmarshal`:** because the free functions cache their decode plan after the first call, the steady-state gap is small — the same simple-struct shape benchmarks at **~265 ns/op (2 allocs)** via `Decoder` versus **~290 ns/op (2 allocs)** via `Unmarshal` on Apple M4 (measurements are hardware-dependent, not a guarantee). `Decoder`'s remaining edge is skipping the per-call cache lookup — and, more importantly, `Compile` validates pattern/tag agreement strictly up front, where the lenient free functions skip misbound fields silently. Use `Decoder` when you'll decode the same shape many times (log parsers, config readers, request handlers); use `Unmarshal` for one-shot extraction.
-
-**Compile-time validation is strict.** `Compile` returns an error (or `MustCompile` panics) if:
-- The pattern is not a valid regex
-- `T` is not a struct
-- A field's `regex:"name"` tag references a group not declared on the pattern (unless paired with `default=`)
-- A `default=` value cannot be converted to its field type
-- A `layout=` option is on a non-`time.Time` field
-
-This is the strictness you want for "compile once" — typos fail at startup, not at first request.
-
-Each failure is categorized by a wrapped sentinel so you can branch on the kind with `errors.Is` instead of parsing the message: `regextra.ErrInvalidPattern` for the bad-regex case, and `regextra.ErrInvalidStruct` for the four destination-shape cases. `MustCompile` panics with the same wrapped error. The sentinels are `Compile`-only — the lenient `Unmarshal` / `UnmarshalAll` path never surfaces them.
-
-```go
-if _, err := regextra.Compile[Person](pattern); err != nil {
-    switch {
-    case errors.Is(err, regextra.ErrInvalidPattern):
-        // bad regular expression
-    case errors.Is(err, regextra.ErrInvalidStruct):
-        // struct/tag shape problem
-    }
-}
-```
-
-`Decoder.One` returns `regextra.ErrNoMatch` (compare with `errors.Is`) when there's no match. Other errors indicate per-field conversion failure on a successful match.
-
-**Typed conversion failures.** When a matched group value can't be converted to its field type, every decode entrypoint (`Unmarshal`, `UnmarshalAll`, `Decoder.One`/`All`/`Iter`) returns a `*regextra.DecodeError` carrying the field name, capture group, raw value, target type, and wrapped cause. Recover it with `errors.As` to branch without parsing message text:
-
-```go
-var de *regextra.DecodeError
-if errors.As(err, &de) {
-    log.Printf("field %s (group %s): cannot parse %q as %s", de.Field, de.Group, de.Value, de.Type)
-}
-```
-
-**Required groups.** A field tagged `regex:",required"` (see the Tag options table under [`Unmarshal`](#unmarshalre-regexpregexp-target-string-v-any-error)) must receive a value: when its group does not participate in the match or matches an empty span and no `default=` supplies one, the same decode entrypoints return a `*regextra.RequiredGroupError` carrying the field name and capture group. It is the per-match presence check, complementing `*DecodeError` (a value that failed conversion) and `*MissingNamedGroupsError` (the static `Validate` check that the pattern declares a group at all):
-
-```go
-var rge *regextra.RequiredGroupError
-if errors.As(err, &rge) {
-    log.Printf("field %s (group %s) is required but had no value", rge.Field, rge.Group)
-}
-```
-
-Constructed errors are prefixed with the entrypoint that produced them (`regextra.Unmarshal:`, `regextra.Decoder.One:`, …); the bare `regextra:` prefix is reserved for package-level sentinels like `ErrNoMatch`, `ErrInvalidPattern`, and `ErrInvalidStruct`. One intended exception: the construction-time errors from `Compile` / `MustCompile` and `Decoder.Encoder()` carry the bare `regextra:` prefix rather than a `regextra.Compile:` / `regextra.Decoder.Encoder:` entrypoint prefix, because they wrap the `ErrInvalidPattern` / `ErrInvalidStruct` / `ErrNotInvertible` sentinels directly — so a `regextra:`-prefixed message there is by design, not a missing prefix. Treat these prefixes as informational — compare against the sentinel or the `*DecodeError` type, not the string.
-
-**Streaming with `Decoder.Iter`:**
-
-```go
-// Pair each match with its decode error so callers can skip individual failures
-// without aborting the whole iteration. Break freely to stop early.
-for v, err := range personDecoder.Iter(input) {
-    if err != nil {
-        log.Printf("skipping bad match: %v", err)
-        continue
-    }
-    process(v)
-}
-```
-
-`Iter` returns an `iter.Seq2[T, error]` (Go 1.23+ range-over-func). Use it for streaming-style consumption (log parsers, scrapers) where you don't want to materialize the full result slice up-front. On a full 100-line corpus its throughput is roughly comparable to `UnmarshalAll` (≈28 µs/op, ~205 allocs/op vs ≈26 µs/op, ~114 allocs/op on Apple M4 — hardware-dependent, not a guarantee); `Iter`'s win is streaming, not raw speed. It skips allocating the full result slice (lower peak memory on large inputs) and decodes lazily. Match-finding still happens in one regex call (Go's stdlib doesn't expose a streaming-find API), but the per-match decode work IS lazy — `break` in the range body avoids decoding the remaining matches.
-
-**Accessors.** A `Decoder` exposes the pattern it was compiled from, so you don't have to keep a copy alongside it:
-
-- `Pattern() string` returns the regex source string — handy for logging and debugging.
-- `Regexp() *regexp.Regexp` returns the underlying compiled `*regexp.Regexp`, so you can reuse it for your own match-finding (e.g. `FindAllIndex`, custom iteration) without recompiling. The returned pointer is shared with the `Decoder`: its exported methods are read-only and safe for concurrent use, but do not mutate shared matcher state on it — in particular don't call `Longest()`, which changes matching semantics for the `Decoder` too.
-
-```go
-dec := regextra.MustCompile[Person](`(?P<name>\w+) is (?P<age>\d+)`)
-dec.Pattern()          // "(?P<name>\\w+) is (?P<age>\\d+)"
-dec.Regexp().FindAllString("Alice is 30 and Bob is 25", -1)
-// []string{"Alice is 30", "Bob is 25"}
-```
-
-`Decoder` instances are safe for concurrent use.
-
-### `(d *Decoder[T]) Encoder() (*Encoder[T], error)`
-
-The typed inverse of `Decoder`, **derived from the decoder's own compiled pattern** — write the pattern once and get the encoder for free, with no separate template to keep in sync. `Encode` followed by a `Decoder.One` / `Unmarshal` on the same pattern round-trips the original struct.
-
-`Encoder()` parses the decoder's pattern with `regexp/syntax` and inverts the **invertible subset** of the grammar into an ordered encode plan:
-
-- **Literal text** is emitted verbatim (regexp escapes like `\.` are already decoded by the parser).
-- **Named capture groups** `(?P<name>…)` become field substitutions: `name` resolves to a struct field with the same rules `Decoder` uses (the field's `regex:"name"` tag if present, otherwise the field's own name, matched case-insensitively; a `regex:"-"` field is excluded). The group's sub-pattern is discarded — the field's value fills the span.
-- **Anchors and zero-width assertions** (`^`, `$`, `\A`, `\z`, `\b`, …) match no text and are dropped.
-- An **unnamed group** whose body is pure literal text is treated as that literal.
-
-```go
-type Person struct {
-    Name string `regex:"name"`
-    Age  int    `regex:"age"`
-}
-
-dec := regextra.MustCompile[Person](`(?P<name>\S+) is (?P<age>\d+)`)
-enc, _ := dec.Encoder()
-
-s, _ := enc.Encode(Person{Name: "Alice", Age: 30})   // "Alice is 30"
-back, _ := dec.One(s)                                 // Person{Name: "Alice", Age: 30}
-```
-
-**Non-invertible patterns fail fast.** Any construct with no single string to emit — an alternation (`|`), a quantifier (`*`, `+`, `?`, `{n,m}`), a character class (`[...]`), an any-character wildcard (`.`), or an unnamed group with non-literal content — appearing **outside** a named capture group makes the pattern non-invertible, and `Encoder()` returns an error wrapping `regextra.ErrNotInvertible` that names the offending construct. (Inside a named capture such constructs are fine: the field's value fills the group.)
-
-**Supported field types:** same set as `Unmarshal` — `string`, all int/uint/float widths, `bool`, `time.Time`, `time.Duration`, and single-level pointers to any of these. `time.Time` encodes as RFC3339Nano by default (the first layout `Decoder` tries, so the output re-parses and sub-second precision survives), or the `layout=` layout when tagged. Any type implementing [`encoding.TextMarshaler`](https://pkg.go.dev/encoding#TextMarshaler) (e.g. `netip.Addr`, `uuid.UUID`) is encoded via `MarshalText`. For caller-defined types, implement `RegexMarshaler` (below).
-
-**Construction-time validation is strict**, mirroring `Compile`: `Encoder()` returns an error if the pattern is not invertible (above), a named group maps to no exported/eligible field, or a mapped field's type can't be encoded (the latter two wrap `regextra.ErrInvalidStruct`). A successful `Encoder()` can only fail at `Encode` time on a runtime value error (a custom marshaler returning an error, or a nil pointer field, which has no string form) — surfaced as a `*regextra.EncodeError` (the encode-side mirror of `DecodeError`).
-
-**Round-trip contract.** `Encode(v)` re-decodes to `v` when each encoded value re-matches the sub-pattern of the group it fills — the caller owns that pairing by writing value-appropriate sub-patterns (a captured word wants `\S+`, not `.*`). The `default=` tag option does not affect encoding (it is a decode-side substitution); `Encode` always emits the field's actual value. Values that collide with a surrounding literal delimiter, or two adjacent captures with no literal between them, have no unambiguous decode boundary and are out of scope. (A future option is to re-match each encoded value against its group's sub-pattern at `Encode` time; that is deliberately not done today.)
-
-`Encoder` instances are safe for concurrent use.
-
-### `RegexMarshaler` interface
-
-The encode-side mirror of `RegexUnmarshaler`. When an `Encoder` field's type satisfies this interface, `Encode` calls `MarshalRegex` instead of the built-in conversion. A type implementing both `RegexMarshaler` and `RegexUnmarshaler` round-trips symmetrically through `Encoder` and `Decoder`.
-
-```go
-type RegexMarshaler interface {
-    MarshalRegex() (string, error)
-}
-```
-
-**Conversion precedence** mirrors the decode side: (1) `RegexMarshaler`; (2) the `time.Time` / `time.Duration` special-cases; (3) `encoding.TextMarshaler`; (4) the built-in string/int/uint/float/bool conversion.
-
-```go
-func (s Status) MarshalRegex() (string, error) {
-    switch s {
-    case StatusOpen:   return "open", nil
-    case StatusClosed: return "closed", nil
-    default:           return "", fmt.Errorf("unknown status: %d", s)
-    }
-}
-```
-
-## Why regextra?
-
-The standard library's `regexp` package requires verbose code to extract named capture groups:
-
-```go
-// Standard library approach (verbose)
-re := regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
-matches := re.FindStringSubmatch("Alice 30")
-if matches != nil {
-    nameIndex := re.SubexpIndex("name")
-    name := matches[nameIndex]  // "Alice"
-}
-
-// regextra approach (simple)
-re := regexp.MustCompile(`(?P<name>\w+) (?P<age>\d+)`)
-name, ok := regextra.FindNamed(re, "Alice 30", "name")  // "Alice", true
-```
-
-## Features
-
-- ✅ **Simple functions** - No wrapper types, works directly with `*regexp.Regexp`
-- ✅ **Named group extraction** - Extract groups by name without index juggling
-- ✅ **Map-based access** - Get all named groups in one call
-- ✅ **Struct unmarshaling** - Type-safe extraction with automatic conversion
-- ✅ **Typed round-trip** - `Encoder[T]` renders a struct back to a string, derived by inverting the decoder's own compiled pattern (no separate template to keep in sync)
-- ✅ **Safe by default** - Built-in nil checks, returns empty values on no match
-- ✅ **Zero dependencies** - Only depends on Go's standard library
+| Symbol | What it does |
+|---|---|
+| [`FindNamed`](https://pkg.go.dev/github.com/jecoms/regextra/v2#FindNamed) | Pull one named group from the first match |
+| [`FindAllNamed`](https://pkg.go.dev/github.com/jecoms/regextra/v2#FindAllNamed) | Pull one named group across all matches |
+| [`NamedGroups`](https://pkg.go.dev/github.com/jecoms/regextra/v2#NamedGroups) | All named groups of one match, as a map |
+| [`AllNamedGroups`](https://pkg.go.dev/github.com/jecoms/regextra/v2#AllNamedGroups) | All named groups of one match, keeping every value of a reused group name |
+| [`NamedGroupsPerMatch`](https://pkg.go.dev/github.com/jecoms/regextra/v2#NamedGroupsPerMatch) | One named-group map per match, across all matches |
+| [`NamedGroupsPerMatchSeq`](https://pkg.go.dev/github.com/jecoms/regextra/v2#NamedGroupsPerMatchSeq) | Lazy (Go 1.23+ range-over-func) form of `NamedGroupsPerMatch` |
+| [`Replace`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Replace) | Substitute named-group spans by name, in every match |
+| [`ReplaceFirst`](https://pkg.go.dev/github.com/jecoms/regextra/v2#ReplaceFirst) | Substitute named-group spans in the first match only |
+| [`ReplaceFunc`](https://pkg.go.dev/github.com/jecoms/regextra/v2#ReplaceFunc) | Substitute named-group spans via a callback over the matched value |
+| [`Validate`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Validate) | Assert at startup that required group names are declared on a pattern |
+| [`Unmarshal`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Unmarshal) | Decode the first match into a struct, with type conversion and `regex:"..."` tags |
+| [`UnmarshalAll`](https://pkg.go.dev/github.com/jecoms/regextra/v2#UnmarshalAll) | Decode every match into a slice of structs |
+| [`Compile`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Compile) / [`MustCompile`](https://pkg.go.dev/github.com/jecoms/regextra/v2#MustCompile) | Build a [`Decoder[T]`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Decoder) with strict upfront validation — compile once, decode many times |
+| [`Decoder.One`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Decoder.One) / [`Decoder.All`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Decoder.All) / [`Decoder.Iter`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Decoder.Iter) | Typed decode of the first match / every match / a lazy match stream |
+| [`Decoder.Encoder`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Decoder.Encoder) | Derive an [`Encoder[T]`](https://pkg.go.dev/github.com/jecoms/regextra/v2#Encoder) — the typed inverse that renders a struct back into a string by inverting the decoder's own pattern |
+| [`RegexUnmarshaler`](https://pkg.go.dev/github.com/jecoms/regextra/v2#RegexUnmarshaler) / [`RegexMarshaler`](https://pkg.go.dev/github.com/jecoms/regextra/v2#RegexMarshaler) | Extension points for caller-defined types on the decode / encode side |
+| [`ErrNoMatch`](https://pkg.go.dev/github.com/jecoms/regextra/v2#ErrNoMatch), [`ErrInvalidPattern`](https://pkg.go.dev/github.com/jecoms/regextra/v2#ErrInvalidPattern), [`ErrInvalidStruct`](https://pkg.go.dev/github.com/jecoms/regextra/v2#ErrInvalidStruct), [`ErrNotInvertible`](https://pkg.go.dev/github.com/jecoms/regextra/v2#ErrNotInvertible) | Sentinel errors — compare with `errors.Is` |
+| [`DecodeError`](https://pkg.go.dev/github.com/jecoms/regextra/v2#DecodeError), [`EncodeError`](https://pkg.go.dev/github.com/jecoms/regextra/v2#EncodeError), [`RequiredGroupError`](https://pkg.go.dev/github.com/jecoms/regextra/v2#RequiredGroupError), [`MissingNamedGroupsError`](https://pkg.go.dev/github.com/jecoms/regextra/v2#MissingNamedGroupsError) | Typed errors — recover with `errors.As` |
+
+## Stability
+
+`regextra` is at v2 and follows strict SemVer. Import it at the `/v2` module path (`github.com/jecoms/regextra/v2`); the v1 line is frozen at the `v1.x` tags.
+
+- Breaking changes ship in the next major version (`v3.0.0`), never in a minor or patch.
+- Minor releases (`v2.x.0`) add features.
+- Patch releases (`v2.x.y`) are fixes only.
+
+v2.0.0 collects the behavior changes made since v1.0.0; see [CHANGELOG.md](./CHANGELOG.md) for the exhaustive list, with every breaking entry marked.
+
+The forward look is tracked in the [issue tracker](https://github.com/Jecoms/regextra/issues).
+
+**What counts as breaking**
+
+- Removing or renaming an exported symbol.
+- Changing the signature of an exported function or method.
+- Changing observable behavior of an existing call (e.g. a previously-returning call now returns an error).
+
+**What does *not* count as breaking**
+
+- Adding a new exported function, type, or method.
+- Adding a new option to the `regex:"..."` struct tag grammar.
+- Accepting additional field types in `Unmarshal` / `UnmarshalAll` / `Decoder`.
+- Changing the wording of error messages. Do not pattern-match on `err.Error()` strings; compare against the exported sentinels (e.g. `regextra.ErrNoMatch`, `regextra.ErrInvalidPattern`, `regextra.ErrInvalidStruct` with `errors.Is`) or recover the typed `*regextra.DecodeError` with `errors.As` instead.
 
 ## License
 

--- a/decoder.go
+++ b/decoder.go
@@ -359,6 +359,11 @@ func (d *Decoder[T]) All(target string) ([]T, error) {
 // lazy, so breaking early avoids the per-match reflect work for the
 // remaining matches.
 //
+// On a fully-consumed input, throughput is roughly comparable to
+// [Decoder.All] / [UnmarshalAll] — Iter's advantage is streaming (no
+// materialized result slice, so lower peak memory on large inputs, plus the
+// lazy decode above), not raw speed.
+//
 // For a slice of all results with a single error, prefer [Decoder.All].
 // For a single match with a sentinel ErrNoMatch, prefer [Decoder.One].
 func (d *Decoder[T]) Iter(target string) iter.Seq2[T, error] {

--- a/decoder.go
+++ b/decoder.go
@@ -360,7 +360,7 @@ func (d *Decoder[T]) All(target string) ([]T, error) {
 // remaining matches.
 //
 // On a fully-consumed input, throughput is roughly comparable to
-// [Decoder.All] / [UnmarshalAll] — Iter's advantage is streaming (no
+// [UnmarshalAll] — Iter's advantage is streaming (no
 // materialized result slice, so lower peak memory on large inputs, plus the
 // lazy decode above), not raw speed.
 //

--- a/encoder.go
+++ b/encoder.go
@@ -114,6 +114,13 @@ type encodeSegment struct {
 // A type that implements both RegexMarshaler and [RegexUnmarshaler] round-trips
 // symmetrically through [Encoder] and [Decoder].
 //
+// Conversion precedence mirrors the decode side (see [RegexUnmarshaler]): for
+// each field, Encode tries (1) RegexMarshaler, (2) the time.Time /
+// time.Duration special-cases, (3) [encoding.TextMarshaler], (4) the built-in
+// string/int/uint/float/bool conversion. A type implementing both
+// RegexMarshaler and [encoding.TextMarshaler] therefore dispatches on
+// MarshalRegex.
+//
 // Example:
 //
 //	type Status int

--- a/regextra.go
+++ b/regextra.go
@@ -205,8 +205,11 @@ does not count as breaking.
 
 # More
 
-The package README has full per-function reference with runnable examples for
-each function.
+This package documentation is the canonical reference for per-symbol
+contracts — each exported symbol's doc comment states the behavior a caller
+may rely on. The repository README is a front page (installation, a quick
+usage tour, an API table linking here, and the stability policy), not a
+second copy of the reference.
 */
 package regextra
 

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -194,7 +194,14 @@ func getDecodePlan(rt reflect.Type, re *regexp.Regexp) ([]fieldDecoder, error) {
 //   - Supports type conversion for string, bool, all int/uint widths,
 //     float32/float64, time.Time, time.Duration, and pointers (any depth)
 //     to any of these; types implementing [RegexUnmarshaler] or
-//     encoding.TextUnmarshaler convert themselves
+//     encoding.TextUnmarshaler convert themselves (see [RegexUnmarshaler]
+//     for the full conversion precedence)
+//   - A nil pointer field is allocated; a non-nil pointer is reused, its
+//     pointee overwritten
+//   - A time.Time field tries these layouts in order: RFC3339Nano, RFC3339,
+//     DateTime ("2006-01-02 15:04:05"), DateOnly ("2006-01-02"), TimeOnly
+//     ("15:04:05") — unless a `layout=` tag option pins one exclusively;
+//     time.Duration is parsed with [time.ParseDuration]
 //   - Unexported fields are ignored
 //   - A group that did not participate in the match (e.g. an optional group),
 //     or that matched an empty span, leaves the field unchanged — unless the
@@ -461,6 +468,20 @@ func resolveGroupValue(value string, found bool, opts map[string]string) (string
 //
 // This is the extension point for caller-defined types that the built-in
 // type switch can't handle (URLs, enums, big numbers, IP addresses, etc.).
+//
+// Conversion precedence: for each field, the decode path tries in order
+//
+//  1. RegexUnmarshaler — the package-specific hook always wins;
+//  2. the time.Time / time.Duration special-cases, so the multi-layout
+//     fallback and the `layout=` tag option are preserved (time.Time
+//     implements [encoding.TextUnmarshaler], but its UnmarshalText accepts
+//     only RFC3339, so it is deliberately not routed through step 3);
+//  3. [encoding.TextUnmarshaler] — for any other type that implements it
+//     (e.g. netip.Addr, math/big.Int, log/slog.Level);
+//  4. the built-in string/int/uint/float/bool conversion.
+//
+// A type implementing both RegexUnmarshaler and [encoding.TextUnmarshaler]
+// therefore dispatches on UnmarshalRegex.
 //
 // Example:
 //

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1615,7 +1615,8 @@ func TestUnmarshal_emptyTagStillFallsBackToFieldName(t *testing.T) {
 // Only the bare `-` excludes: a leading `-` followed by options parses `-` as
 // the group name, which matches no group, so the field falls through to its
 // `default`. The documented boundary in three doc locations (parseFieldTag
-// godoc, README, CHANGELOG), guarded here so it can't silently regress.
+// godoc, package-doc Tag grammar, CHANGELOG), guarded here so it can't
+// silently regress.
 func TestUnmarshal_dashWithOptionsIsNotExcluded(t *testing.T) {
 	type Person struct {
 		Name string `regex:"name"`


### PR DESCRIPTION
## Summary
- Cuts `README.md` from 546 to 113 lines: hook + badges, Installation, the existing Usage block verbatim, a one-row-per-symbol **API table** linking pkg.go.dev anchors, Stability (kept as-is), License. The per-function reference (old lines ~84–513) is deleted; the package doc on pkg.go.dev is now the single source of truth for per-symbol contracts.
- **Ports README-only contract text into godoc before deleting it** (the step-1 audit gate from the issue plan): the 4-step conversion precedence (now on `RegexUnmarshaler`, mirrored on `RegexMarshaler`, including the time.Time-implements-TextUnmarshaler-but-RFC3339-only nuance), the exact `time.Time` layout fallback list and the nil-pointer-allocated / non-nil-reused rule (now on `Unmarshal`), and `Iter`'s "streaming, not raw speed" guidance (now on `Decoder.Iter`).
- Rewrites `regextra.go`'s `# More` section to declare the package documentation canonical and the README a front page, and relaxes CONTRIBUTING's duplicate-write rule in its three README spots to "add a row to the README API table".

## Judgment calls (autonomous mode)
- **Hardware benchmark figures dropped, not ported.** The README's ~265 vs ~290 ns/op (Decoder vs Unmarshal) and ≈28 vs ≈26 µs/op (Iter vs UnmarshalAll) numbers are Apple M4 measurements, not contract; the qualitative guidance they supported ("steady-state gap is small", "Iter's win is streaming") already lives in the package doc's `# Performance` section and now in `Decoder.Iter`'s doc. Raw numbers in godoc would go stale with no benchstat gate.
- **Already-covered audit candidates left alone:** the `Regexp()` `Longest()` caveat, the `regex:"-"` vs `regex:"-,opts"` distinction, and the `ReplaceFunc` nil-`fn` panic rule were confirmed present in godoc — no port needed.
- README examples being deleted are all represented as godoc doc-comment examples and/or `Example*` tests (`ExampleCompile`, `ExampleDecoder_Iter`, `ExampleDecoder_Encoder_roundTrip`, …) — no example coverage lost.
- **`"stability contract since v1"` grep family intentionally shrinks 4 -> 3 sites.** #207 unified that phrase across four grep-able sites (regextra.go, unmarshal.go, unmarshal_test.go, README.md) so drift audits find the family as one unit; this PR's README cut removes the README site along with the reference section it lived in. The three in-code sites remain the family — the shrink is deliberate, not an accidental deletion.
- **Base note:** this work was originally stacked on #207 per the issue plan; #207 merged (squash) while this PR was being prepared, so the change was rebased onto the post-#207 `main` and targets `main` directly — #207's phrasing fixes are incorporated in the base.

## Test plan
- [x] `gofmt -s -l .` clean, `go vet ./...` and `go test ./...` pass, `golangci-lint run` 0 issues (doc-only change, no behavior)
- [x] All 30 pkg.go.dev anchors in the API table verified against `go doc <Symbol>` (exact exported identifiers, incl. `Decoder.Iter`-style method anchors)
- [x] Surviving cross-references intact: `README.md#stability` (linked from CONTRIBUTING and the package doc's `# Stability`) still resolves

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)
